### PR TITLE
Adding checks for tzdata in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu
 RUN if (dpkg -l | grep -cq tzdata); then \
         echo "tzdata package already installed! Skipping tzdata installation"; \
     else \
-        echo "Installing tzdata to avoid go panic caused by missing timezone data" \
-        apt-get update && apt-get install tzdata -y --no-install-recommends apt-utils; \
+        echo "Installing tzdata to avoid go panic caused by missing timezone data"; \
+        apt-get update; \
+        apt-get install tzdata -y --no-install-recommends apt-utils; \
     fi
 COPY kube-monkey /kube-monkey

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM ubuntu
-RUN apt-get update
-RUN apt-get install tzdata -y
+RUN if (dpkg -l | grep -cq tzdata); then \
+        echo "tzdata package already installed!"; \
+    else \
+        apt-get update && apt-get install tzdata -y --no-install-recommends apt-utils; \
+    fi
 COPY kube-monkey /kube-monkey

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ RUN if (dpkg -l | grep -cq tzdata); then \
         echo "tzdata package already installed! Skipping tzdata installation"; \
     else \
         echo "Installing tzdata to avoid go panic caused by missing timezone data"; \
-        apt-get update; \
-        apt-get install tzdata -y --no-install-recommends apt-utils; \
+        apt-get update && apt-get install tzdata -y --no-install-recommends apt-utils; \
     fi
 COPY kube-monkey /kube-monkey

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM ubuntu
 RUN if (dpkg -l | grep -cq tzdata); then \
-        echo "tzdata package already installed!"; \
+        echo "tzdata package already installed! Skipping tzdata installation"; \
     else \
+        echo "Installing tzdata to avoid go panic caused by missing timezone data" \
         apt-get update && apt-get install tzdata -y --no-install-recommends apt-utils; \
     fi
 COPY kube-monkey /kube-monkey


### PR DESCRIPTION
Locally, I pull first from artifactory which might have a custom version of ubuntu that has tzdata already. The conditional makes extending the use in other environments a lot easier.

Also takes care of warning `debconf: delaying package configuration, since apt-utils is not installed` using flag `--no-install-recommends apt-utils` 
https://github.com/phusion/baseimage-docker/issues/319