### PR TITLE
Bugfix for DivBy0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
-TAG = v0.2.1
+TAG = v0.2.2
 
 .PHONY: all build container clean
 

--- a/chaos/chaos.go
+++ b/chaos/chaos.go
@@ -122,7 +122,7 @@ func (c *Chaos) terminate(clientset *kube.Clientset) error {
 		return c.Victim().DeleteRandomPods(clientset, killValue)
 	case config.KillRandomLabelValue:
 		r := rand.New(rand.NewSource(time.Now().UnixNano()))
-		return c.Victim().DeleteRandomPods(clientset, killValue*100/r.Intn(101))
+		return c.Victim().DeleteRandomPods(clientset, killValue*100/r.Intn(100)+1)
 	default:
 		return fmt.Errorf("Failed to recognize KillValue label for %s %s. Error: %v", c.Victim().Kind(), c.Victim().Name(), err.Error())
 	}


### PR DESCRIPTION
fixes
panic: runtime error: integer divide by zero
goroutine 1546 [running]:
github.com/asobti/kube-monkey/chaos.(*Chaos).terminate(0xc420974360, 0xc42014a3c0, 0x0, 0x0)
        /home/klei22/go/src/github.com/asobti/kube-monkey/chaos/chaos.go:125 +0x498
github.com/asobti/kube-monkey/chaos.(*Chaos).Execute(0xc420974360, 0xc420638b40)
        /home/klei22/go/src/github.com/asobti/kube-monkey/chaos/chaos.go:66 +0x246
github.com/asobti/kube-monkey/chaos.(*Chaos).Schedule(0xc420974360, 0xc420638b40)
        /home/klei22/go/src/github.com/asobti/kube-monkey/chaos/chaos.go:42 +0x51
created by github.com/asobti/kube-monkey/kubemonkey.ScheduleTerminations
        /home/klei22/go/src/github.com/asobti/kube-monkey/kubemonkey/kubemonkey.go:57 +0xc5