### PR TITLE
upgrade kubernetes client-go api to apps/v1

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -6,8 +6,7 @@ import:
 - package: k8s.io/api
   subpackages:
   - core/v1
-  - apps/v1beta1
-  - extensions/v1beta1
+  - apps/v1
 - package: k8s.io/apimachinery
   subpackages:
   - pkg/apis/meta/v1

--- a/vendor/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/net/http.go
@@ -276,7 +276,7 @@ func NewProxierWithNoProxyCIDR(delegate func(req *http.Request) (*url.URL, error
 	}
 
 	return func(req *http.Request) (*url.URL, error) {
-		ip := net.ParseIP(req.URL.Hostname())
+		ip := net.ParseIP(req.URL.Host)
 		if ip == nil {
 			return delegate(req)
 		}

--- a/victims/factory/deployments/deployments.go
+++ b/victims/factory/deployments/deployments.go
@@ -7,7 +7,7 @@ import (
 	"github.com/asobti/kube-monkey/config"
 	"github.com/asobti/kube-monkey/victims"
 
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/apps/v1"
 )
 
 type Deployment struct {
@@ -15,7 +15,7 @@ type Deployment struct {
 }
 
 // Create a new instance of Deployment
-func New(dep *v1beta1.Deployment) (*Deployment, error) {
+func New(dep *v1.Deployment) (*Deployment, error) {
 	ident, err := identifier(dep)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func New(dep *v1beta1.Deployment) (*Deployment, error) {
 // This label should be unique to a deployment, and is used to
 // identify the pods that belong to this deployment, as pods
 // inherit labels from the Deployment
-func identifier(kubekind *v1beta1.Deployment) (string, error) {
+func identifier(kubekind *v1.Deployment) (string, error) {
 	identifier, ok := kubekind.Labels[config.IdentLabelKey]
 	if !ok {
 		return "", fmt.Errorf("%T %s does not have %s label", kubekind, kubekind.Name, config.IdentLabelKey)
@@ -44,7 +44,7 @@ func identifier(kubekind *v1beta1.Deployment) (string, error) {
 
 // Read the mean-time-between-failures value defined by the Deployment
 // in the label defined by config.MtbfLabelKey
-func meanTimeBetweenFailures(kubekind *v1beta1.Deployment) (int, error) {
+func meanTimeBetweenFailures(kubekind *v1.Deployment) (int, error) {
 	mtbf, ok := kubekind.Labels[config.MtbfLabelKey]
 	if !ok {
 		return -1, fmt.Errorf("%T %s does not have %s label", kubekind, kubekind.Name, config.MtbfLabelKey)

--- a/victims/factory/deployments/deployments_test.go
+++ b/victims/factory/deployments/deployments_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/asobti/kube-monkey/config"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,9 +15,9 @@ const (
 	NAMESPACE  = metav1.NamespaceDefault
 )
 
-func newDeployment(name string, labels map[string]string) v1beta1.Deployment {
+func newDeployment(name string, labels map[string]string) v1.Deployment {
 
-	return v1beta1.Deployment{
+	return v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: NAMESPACE,
@@ -38,7 +38,7 @@ func TestNew(t *testing.T) {
 	depl, err := New(&v1depl)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "v1beta1.Deployment", depl.Kind())
+	assert.Equal(t, "v1.Deployment", depl.Kind())
 	assert.Equal(t, NAME, depl.Name())
 	assert.Equal(t, NAMESPACE, depl.Namespace())
 	assert.Equal(t, IDENTIFIER, depl.Identifier())

--- a/victims/factory/deployments/eligible_deployments.go
+++ b/victims/factory/deployments/eligible_deployments.go
@@ -18,7 +18,7 @@ import (
 
 // Get all eligible deployments that opted in (filtered by config.EnabledLabel)
 func EligibleDeployments(clientset kube.Interface, namespace string, filter *metav1.ListOptions) (eligVictims []victims.Victim, err error) {
-	enabledVictims, err := clientset.ExtensionsV1beta1().Deployments(namespace).List(*filter)
+	enabledVictims, err := clientset.AppsV1().Deployments(namespace).List(*filter)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func EligibleDeployments(clientset kube.Interface, namespace string, filter *met
 
 // Checks if the deployment is currently enrolled in kube-monkey
 func (d *Deployment) IsEnrolled(clientset kube.Interface) (bool, error) {
-	deployment, err := clientset.ExtensionsV1beta1().Deployments(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
+	deployment, err := clientset.AppsV1().Deployments(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
 	if err != nil {
 		return false, nil
 	}
@@ -56,7 +56,7 @@ func (d *Deployment) IsEnrolled(clientset kube.Interface) (bool, error) {
 
 // Returns current killtype config label for update
 func (d *Deployment) KillType(clientset kube.Interface) (string, error) {
-	deployment, err := clientset.ExtensionsV1beta1().Deployments(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
+	deployment, err := clientset.AppsV1().Deployments(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -71,7 +71,7 @@ func (d *Deployment) KillType(clientset kube.Interface) (string, error) {
 
 // Returns current killvalue config label for update
 func (d *Deployment) KillValue(clientset kube.Interface) (int, error) {
-	deployment, err := clientset.ExtensionsV1beta1().Deployments(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
+	deployment, err := clientset.AppsV1().Deployments(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
 	if err != nil {
 		return -1, err
 	}

--- a/victims/factory/statefulsets/eligible_statefulsets.go
+++ b/victims/factory/statefulsets/eligible_statefulsets.go
@@ -18,7 +18,7 @@ import (
 
 // Get all eligible statefulsets that opted in (filtered by config.EnabledLabel)
 func EligibleStatefulSets(clientset kube.Interface, namespace string, filter *metav1.ListOptions) (eligVictims []victims.Victim, err error) {
-	enabledVictims, err := clientset.AppsV1beta1().StatefulSets(namespace).List(*filter)
+	enabledVictims, err := clientset.AppsV1().StatefulSets(namespace).List(*filter)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func EligibleStatefulSets(clientset kube.Interface, namespace string, filter *me
 
 // Checks if the statefulset is currently enrolled in kube-monkey
 func (ss *StatefulSet) IsEnrolled(clientset kube.Interface) (bool, error) {
-	statefulset, err := clientset.AppsV1beta1().StatefulSets(ss.Namespace()).Get(ss.Name(), metav1.GetOptions{})
+	statefulset, err := clientset.AppsV1().StatefulSets(ss.Namespace()).Get(ss.Name(), metav1.GetOptions{})
 	if err != nil {
 		return false, nil
 	}
@@ -56,7 +56,7 @@ func (ss *StatefulSet) IsEnrolled(clientset kube.Interface) (bool, error) {
 
 // Returns current killtype config label for update
 func (ss *StatefulSet) KillType(clientset kube.Interface) (string, error) {
-	statefulset, err := clientset.AppsV1beta1().StatefulSets(ss.Namespace()).Get(ss.Name(), metav1.GetOptions{})
+	statefulset, err := clientset.AppsV1().StatefulSets(ss.Namespace()).Get(ss.Name(), metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
@@ -71,7 +71,7 @@ func (ss *StatefulSet) KillType(clientset kube.Interface) (string, error) {
 
 // Returns current killvalue config label for update
 func (ss *StatefulSet) KillValue(clientset kube.Interface) (int, error) {
-	statefulset, err := clientset.AppsV1beta1().StatefulSets(ss.Namespace()).Get(ss.Name(), metav1.GetOptions{})
+	statefulset, err := clientset.AppsV1().StatefulSets(ss.Namespace()).Get(ss.Name(), metav1.GetOptions{})
 	if err != nil {
 		return -1, err
 	}

--- a/victims/factory/statefulsets/statefulset_test.go
+++ b/victims/factory/statefulsets/statefulset_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/asobti/kube-monkey/config"
 	"github.com/stretchr/testify/assert"
-	"k8s.io/api/apps/v1beta1"
+	"k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,9 +15,9 @@ const (
 	NAMESPACE  = metav1.NamespaceDefault
 )
 
-func newStatefulSet(name string, labels map[string]string) v1beta1.StatefulSet {
+func newStatefulSet(name string, labels map[string]string) v1.StatefulSet {
 
-	return v1beta1.StatefulSet{
+	return v1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: NAMESPACE,
@@ -38,7 +38,7 @@ func TestNew(t *testing.T) {
 	stfs, err := New(&v1stfs)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "v1beta1.StatefulSet", stfs.Kind())
+	assert.Equal(t, "v1.StatefulSet", stfs.Kind())
 	assert.Equal(t, NAME, stfs.Name())
 	assert.Equal(t, NAMESPACE, stfs.Namespace())
 	assert.Equal(t, IDENTIFIER, stfs.Identifier())

--- a/victims/factory/statefulsets/statefulsets.go
+++ b/victims/factory/statefulsets/statefulsets.go
@@ -7,7 +7,7 @@ import (
 	"github.com/asobti/kube-monkey/config"
 	"github.com/asobti/kube-monkey/victims"
 
-	"k8s.io/api/apps/v1beta1"
+	"k8s.io/api/apps/v1"
 )
 
 type StatefulSet struct {
@@ -15,7 +15,7 @@ type StatefulSet struct {
 }
 
 // Create a new instance of StatefulSet
-func New(ss *v1beta1.StatefulSet) (*StatefulSet, error) {
+func New(ss *v1.StatefulSet) (*StatefulSet, error) {
 	ident, err := identifier(ss)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func New(ss *v1beta1.StatefulSet) (*StatefulSet, error) {
 // This label should be unique to a statefulset, and is used to
 // identify the pods that belong to this statefulset, as pods
 // inherit labels from the StatefulSet
-func identifier(kubekind *v1beta1.StatefulSet) (string, error) {
+func identifier(kubekind *v1.StatefulSet) (string, error) {
 	identifier, ok := kubekind.Labels[config.IdentLabelKey]
 	if !ok {
 		return "", fmt.Errorf("%T %s does not have %s label", kubekind, kubekind.Name, config.IdentLabelKey)
@@ -44,7 +44,7 @@ func identifier(kubekind *v1beta1.StatefulSet) (string, error) {
 
 // Read the mean-time-between-failures value defined by the StatefulSet
 // in the label defined by config.MtbfLabelKey
-func meanTimeBetweenFailures(kubekind *v1beta1.StatefulSet) (int, error) {
+func meanTimeBetweenFailures(kubekind *v1.StatefulSet) (int, error) {
 	mtbf, ok := kubekind.Labels[config.MtbfLabelKey]
 	if !ok {
 		return -1, fmt.Errorf("%T %s does not have %s label", kubekind, kubekind.Name, config.MtbfLabelKey)


### PR DESCRIPTION
1.Describe what this PR did

Upgrade kubernetes client-go api to apps/v1, including deployments and statefulsets.

2.Does this pull request fix one issue?

During my debug for the higher kubernetes version like v1.9.x, I found some issues. Since the client-go api apps/v1 is stable, I made the upgration.

3.Describe how you did it

Upgrade client-go api to apps/v1.

4.Describe how to verify it
```
/usr/local/go/bin/go test -v github.com/asobti/kube-monkey/victims/factory/deployments -run "^TestNew|TestInvalidIdentifier|TestInvalidMtbf$"
ok  	github.com/asobti/kube-monkey/victims/factory/deployments	0.088s

/usr/local/go/bin/go test -v github.com/asobti/kube-monkey/victims/factory/deployments -run "^TestEligibleDeployments|TestIsEnrolled|TestIsNotEnrolled|TestKillType|TestKillValue$"
ok  	github.com/asobti/kube-monkey/victims/factory/deployments	0.094s

/usr/local/go/bin/go test -v github.com/asobti/kube-monkey/victims/factory/statefulsets -run "^TestNew|TestInvalidIdentifier|TestInvalidMtbf$"
ok  	github.com/asobti/kube-monkey/victims/factory/statefulsets	0.092s

/usr/local/go/bin/go test -v github.com/asobti/kube-monkey/victims/factory/statefulsets -run "^TestEligibleStatefulSets|TestIsEnrolled|TestIsNotEnrolled|TestKillType|TestKillValue$"
ok  	github.com/asobti/kube-monkey/victims/factory/statefulsets	0.090s
```

5.Special notes for reviews
None
