### PR TITLE
Change assertion in TestTimezon to contains

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"os"
 	"testing"
 	"time"
 
@@ -51,7 +50,7 @@ func (s *ConfigTestSuite) TestTimezone() {
 
 	// avoid Exit(255) on glog.Fatal
 	monkey.Patch(glog.Fatal, func(a ...interface{}) {
-		s.Equal(a[0], "cannot find nolnexistent in zip file "+os.Getenv("GOROOT")+"/lib/time/zoneinfo.zip")
+		s.Contains(a[0], "cannot find nolnexistent in zip file")
 	})
 	defer func() { monkey.Unpatch(glog.Fatal) }()
 	s.Equal((*time.Location)(nil), Timezone())


### PR DESCRIPTION
Depending on platform and GO installation method, the path for
the zip file can be different which will make this test fail.

Example

Error:          Not equal:
expected: "cannot find nolnexistent in zip file
             /usr/local/Cellar/go/1.10.3/libexec/lib/time/zoneinfo.zip"
actual  : "cannot find nolnexistent in zip file /lib/time/zoneinfo.zip"