### PR TITLE
Add whitelist to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ run_hour = 8                             # Run scheduling at 8am on weekdays
 start_hour = 10                          # Don't schedule any pod deaths before 10am
 end_hour = 16                            # Don't schedule any pod deaths after 4pm
 blacklisted_namespaces = ["kube-system"] # Critical apps live here
+whitelisted_namespaces = ["default"]     # Kill only default namespace apps
 time_zone = "America/New_York"           # Set tzdata timezone example. Note the field is time_zone not timezone
 ```
 


### PR DESCRIPTION
As per https://github.com/asobti/kube-monkey/issues/78, this will help people who want to come in and deploy quickly. I think when I made the PR to add whitelists we discussed the default whitelist behavior and decided to err on the safe side and whitelist only the default namespace rather than not have a whitelist.