### PR TITLE
Remove invalid ref to err

### DIFF
--- a/chaos/chaos.go
+++ b/chaos/chaos.go
@@ -126,7 +126,7 @@ func (c *Chaos) terminate(clientset kube.Interface) error {
 		killNum := c.Victim().KillNumberForFixedPercentage(clientset, killValue)
 		return c.Victim().DeleteRandomPods(clientset, killNum)
 	default:
-		return fmt.Errorf("Failed to recognize KillValue label for %s %s. Error: %v", c.Victim().Kind(), c.Victim().Name(), err.Error())
+		return fmt.Errorf("Failed to recognize KillValue label for %s %s", c.Victim().Kind(), c.Victim().Name())
 	}
 }
 

--- a/chaos/chaos.go
+++ b/chaos/chaos.go
@@ -126,7 +126,7 @@ func (c *Chaos) terminate(clientset kube.Interface) error {
 		killNum := c.Victim().KillNumberForFixedPercentage(clientset, killValue)
 		return c.Victim().DeleteRandomPods(clientset, killNum)
 	default:
-		return fmt.Errorf("Failed to recognize KillValue label for %s %s", c.Victim().Kind(), c.Victim().Name())
+		return fmt.Errorf("Failed to recognize KillType label for %s %s", c.Victim().Kind(), c.Victim().Name())
 	}
 }
 

--- a/chaos/chaos_test.go
+++ b/chaos/chaos_test.go
@@ -123,6 +123,15 @@ func (s *ChaosTestSuite) TestTerminateKillFixedPercentage() {
 	v.AssertExpectations(s.T())
 }
 
+func (s *ChaosTestSuite) TestInvalidKillType() {
+	v := s.chaos.victim.(*victimMock)
+	killValue := 1
+	v.On("KillType", s.client).Return("InvalidKillTypeHere", nil)
+	v.On("KillValue", s.client).Return(killValue, nil)
+	_ = s.chaos.terminate(s.client)
+	v.AssertExpectations(s.T())
+}
+
 func (s *ChaosTestSuite) TestDurationToKillTime() {
 	t := s.chaos.DurationToKillTime()
 	s.WithinDuration(s.chaos.KillAt(), time.Now(), t+time.Millisecond)

--- a/chaos/chaos_test.go
+++ b/chaos/chaos_test.go
@@ -130,7 +130,7 @@ func (s *ChaosTestSuite) TestInvalidKillType() {
 	v.On("KillValue", s.client).Return(killValue, nil)
 	err := s.chaos.terminate(s.client)
 	v.AssertExpectations(s.T())
-	s.EqualError(err, "Failed to recognize KillValue label for Pod "+v.Name()+"")
+	s.EqualError(err, "Failed to recognize KillType label for Pod "+v.Name()+"")
 }
 
 func (s *ChaosTestSuite) TestDurationToKillTime() {

--- a/chaos/chaos_test.go
+++ b/chaos/chaos_test.go
@@ -128,8 +128,9 @@ func (s *ChaosTestSuite) TestInvalidKillType() {
 	killValue := 1
 	v.On("KillType", s.client).Return("InvalidKillTypeHere", nil)
 	v.On("KillValue", s.client).Return(killValue, nil)
-	_ = s.chaos.terminate(s.client)
+	err := s.chaos.terminate(s.client)
 	v.AssertExpectations(s.T())
+	s.EqualError(err, "Failed to recognize KillValue label for Pod "+v.Name()+"")
 }
 
 func (s *ChaosTestSuite) TestDurationToKillTime() {


### PR DESCRIPTION
Using an invalid kill type causes a "invalid memory address or nil pointer" error to occur.
This is caused by a reference to an uninitialised err.

This pull request fixes issue #96.