### PR TITLE
Updating deployment to fix resources positioning in deployment file

### DIFF
--- a/helm/kubemonkey/templates/deployment.yaml
+++ b/helm/kubemonkey/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
           command:
              - "/kube-monkey"
           args: ["-v={{ .Values.args.logLevel }}", "-log_dir={{ .Values.args.logDir }}"]
+          resources:
+{{- toYaml .Values.resources | trimSuffix "\n" | nindent 12 }}
           volumeMounts:
              - name: config-volume
                mountPath: "/etc/kube-monkey"
@@ -35,8 +37,6 @@ spec:
         - name: config-volume
           configMap:
             name: {{ template "kubemonkey.fullname" . }}
-          resources:
-{{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}


### PR DESCRIPTION
This is to fix an issue that's relevant only in the context of having `resources` set for `kube-monkey`

### PROBLEM
When running `helm install --name my-release kubemonkey` it returns
`unable to CREATE Deployment: no spec.template.spec.containers[*].resources set,`. 

#### WHY?
This is because the `resources` appear under `volume` as per the current `deployment` definition.

### FIX
This is to update the deployment so that it looks like `spec -> containers -> resources` 

### NOTE
An instance of `kube-monkey` has been deployed successfully with modified `deployment`
