### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/victims/factory/daemonsets/eligible_daemonsets.go
+++ b/victims/factory/daemonsets/eligible_daemonsets.go
@@ -45,7 +45,7 @@ func EligibleDaemonSets(clientset kube.Interface, namespace string, filter *meta
 
 /* Below methods are used to verify the victim's attributes have not changed at the scheduled time of termination */
 
-// Checks if the daemonset is currently enrolled in kube-monkey
+// IsEnrolled checks if the daemonset is currently enrolled in kube-monkey
 func (d *DaemonSet) IsEnrolled(clientset kube.Interface) (bool, error) {
 	daemonset, err := clientset.AppsV1().DaemonSets(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
 	if err != nil {
@@ -54,7 +54,7 @@ func (d *DaemonSet) IsEnrolled(clientset kube.Interface) (bool, error) {
 	return daemonset.Labels[config.EnabledLabelKey] == config.EnabledLabelValue, nil
 }
 
-// Returns current killtype config label for update
+// KillType returns current killtype config label for update
 func (d *DaemonSet) KillType(clientset kube.Interface) (string, error) {
 	daemonset, err := clientset.AppsV1().DaemonSets(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
 	if err != nil {
@@ -69,7 +69,7 @@ func (d *DaemonSet) KillType(clientset kube.Interface) (string, error) {
 	return killType, nil
 }
 
-// Returns current killvalue config label for update
+// KillValue returns current killvalue config label for update
 func (d *DaemonSet) KillValue(clientset kube.Interface) (int, error) {
 	daemonset, err := clientset.AppsV1().DaemonSets(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
 	if err != nil {

--- a/victims/factory/deployments/eligible_deployments.go
+++ b/victims/factory/deployments/eligible_deployments.go
@@ -45,7 +45,7 @@ func EligibleDeployments(clientset kube.Interface, namespace string, filter *met
 
 /* Below methods are used to verify the victim's attributes have not changed at the scheduled time of termination */
 
-// Checks if the deployment is currently enrolled in kube-monkey
+// IsEnrolled checks if the deployment is currently enrolled in kube-monkey
 func (d *Deployment) IsEnrolled(clientset kube.Interface) (bool, error) {
 	deployment, err := clientset.AppsV1().Deployments(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
 	if err != nil {
@@ -54,7 +54,7 @@ func (d *Deployment) IsEnrolled(clientset kube.Interface) (bool, error) {
 	return deployment.Labels[config.EnabledLabelKey] == config.EnabledLabelValue, nil
 }
 
-// Returns current killtype config label for update
+// KillType returns current killtype config label for update
 func (d *Deployment) KillType(clientset kube.Interface) (string, error) {
 	deployment, err := clientset.AppsV1().Deployments(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
 	if err != nil {
@@ -69,7 +69,7 @@ func (d *Deployment) KillType(clientset kube.Interface) (string, error) {
 	return killType, nil
 }
 
-// Returns current killvalue config label for update
+// KillValue returns current killvalue config label for update
 func (d *Deployment) KillValue(clientset kube.Interface) (int, error) {
 	deployment, err := clientset.AppsV1().Deployments(d.Namespace()).Get(d.Name(), metav1.GetOptions{})
 	if err != nil {

--- a/victims/factory/statefulsets/eligible_statefulsets.go
+++ b/victims/factory/statefulsets/eligible_statefulsets.go
@@ -45,7 +45,7 @@ func EligibleStatefulSets(clientset kube.Interface, namespace string, filter *me
 
 /* Below methods are used to verify the victim's attributes have not changed at the scheduled time of termination */
 
-// Checks if the statefulset is currently enrolled in kube-monkey
+// IsEnrolled checks if the statefulset is currently enrolled in kube-monkey
 func (ss *StatefulSet) IsEnrolled(clientset kube.Interface) (bool, error) {
 	statefulset, err := clientset.AppsV1().StatefulSets(ss.Namespace()).Get(ss.Name(), metav1.GetOptions{})
 	if err != nil {
@@ -54,7 +54,7 @@ func (ss *StatefulSet) IsEnrolled(clientset kube.Interface) (bool, error) {
 	return statefulset.Labels[config.EnabledLabelKey] == config.EnabledLabelValue, nil
 }
 
-// Returns current killtype config label for update
+// KillType returns current killtype config label for update
 func (ss *StatefulSet) KillType(clientset kube.Interface) (string, error) {
 	statefulset, err := clientset.AppsV1().StatefulSets(ss.Namespace()).Get(ss.Name(), metav1.GetOptions{})
 	if err != nil {
@@ -69,7 +69,7 @@ func (ss *StatefulSet) KillType(clientset kube.Interface) (string, error) {
 	return killType, nil
 }
 
-// Returns current killvalue config label for update
+// KillValue returns current killvalue config label for update
 func (ss *StatefulSet) KillValue(clientset kube.Interface) (int, error) {
 	statefulset, err := clientset.AppsV1().StatefulSets(ss.Namespace()).Get(ss.Name(), metav1.GetOptions{})
 	if err != nil {

--- a/victims/victims.go
+++ b/victims/victims.go
@@ -94,7 +94,7 @@ func (v *VictimBase) Mtbf() int {
 	return v.mtbf
 }
 
-// Returns a list of running pods for the victim
+// RunningPods returns a list of running pods for the victim
 func (v *VictimBase) RunningPods(clientset kube.Interface) (runningPods []v1.Pod, err error) {
 	pods, err := v.Pods(clientset)
 	if err != nil {
@@ -110,7 +110,7 @@ func (v *VictimBase) RunningPods(clientset kube.Interface) (runningPods []v1.Pod
 	return runningPods, nil
 }
 
-// Returns a list of pods under the victim
+// Pods returns a list of pods under the victim
 func (v *VictimBase) Pods(clientset kube.Interface) ([]v1.Pod, error) {
 	labelSelector, err := labelFilterForPods(v.identifier)
 	if err != nil {
@@ -124,7 +124,7 @@ func (v *VictimBase) Pods(clientset kube.Interface) ([]v1.Pod, error) {
 	return podlist.Items, nil
 }
 
-// Removes specified pod for victim
+// DeletePod removes specified pod for victim
 func (v *VictimBase) DeletePod(clientset kube.Interface, podName string) error {
 	if config.DryRun() {
 		glog.Infof("[DryRun Mode] Terminated pod %s for %s/%s", podName, v.namespace, v.name)
@@ -154,7 +154,7 @@ func (v *VictimBase) GetDeleteOptsForPod(pod *v1.Pod) *metav1.DeleteOptions {
 	}
 }
 
-// Removes specified number of random pods for the victim
+// DeleteRandomPods removes specified number of random pods for the victim
 func (v *VictimBase) DeleteRandomPods(clientset kube.Interface, killNum int) error {
 	// Pick a target pod to delete
 	pods, err := v.RunningPods(clientset)
@@ -218,7 +218,7 @@ func (v *VictimBase) DeleteRandomPod(clientset kube.Interface) error {
 	return v.DeletePod(clientset, targetPod)
 }
 
-// Check if this victim is blacklisted
+// IsBlacklisted checks if this victim is blacklisted
 func (v *VictimBase) IsBlacklisted() bool {
 	if config.BlacklistEnabled() {
 		blacklist := config.BlacklistedNamespaces()
@@ -227,7 +227,7 @@ func (v *VictimBase) IsBlacklisted() bool {
 	return false
 }
 
-// Check if this victim is whitelisted
+// IsWhitelisted checks if this victim is whitelisted
 func (v *VictimBase) IsWhitelisted() bool {
 	if config.WhitelistEnabled() {
 		whitelist := config.WhitelistedNamespaces()
@@ -261,7 +261,7 @@ func RandomPodName(pods []v1.Pod) string {
 	return pods[randIndex].Name
 }
 
-// Returns the number of pods to kill based on the number of all running pods
+// KillNumberForKillingAll returns the number of pods to kill based on the number of all running pods
 func (v *VictimBase) KillNumberForKillingAll(clientset kube.Interface) (int, error) {
 	killNum, err := v.numberOfRunningPods(clientset)
 	if err != nil {
@@ -271,7 +271,7 @@ func (v *VictimBase) KillNumberForKillingAll(clientset kube.Interface) (int, err
 	return killNum, nil
 }
 
-// Returns the number of pods to kill based on a kill percentage and the number of running pods
+// KillNumberForFixedPercentage returns the number of pods to kill based on a kill percentage and the number of running pods
 func (v *VictimBase) KillNumberForFixedPercentage(clientset kube.Interface, killPercentage int) (int, error) {
 	if killPercentage == 0 {
 		glog.V(6).Infof("Not terminating any pods for %s %s as kill percentage is 0\n", v.kind, v.name)
@@ -293,7 +293,7 @@ func (v *VictimBase) KillNumberForFixedPercentage(clientset kube.Interface, kill
 	return killNum, nil
 }
 
-// Returns a number of pods to kill based on a a random kill percentage (between 0 and maxPercentage) and the number of running pods
+// KillNumberForMaxPercentage returns a number of pods to kill based on a a random kill percentage (between 0 and maxPercentage) and the number of running pods
 func (v *VictimBase) KillNumberForMaxPercentage(clientset kube.Interface, maxPercentage int) (int, error) {
 	if maxPercentage == 0 {
 		glog.V(6).Infof("Not terminating any pods for %s %s as kill percentage is 0", v.kind, v.name)


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?