### PR TITLE
Correct the default value

### DIFF
--- a/helm/kubemonkey/README.md
+++ b/helm/kubemonkey/README.md
@@ -82,7 +82,7 @@ $ helm get manifest my-release
 | `replicaCount`            | number of replicas to run                           | 1                                |
 | `rbac.enabled`            | rbac enabled or not                                 | true                             |
 | `image.tag.IfNotPresent`  | image pull logic                                    | IfNotPresent                     |
-| `config.dryRun`           | will not kill pods, only logs behaviour             | false                            |
+| `config.dryRun`           | will not kill pods, only logs behaviour             | true                            |
 | `config.runHour`          | schedule start time in 24hr format                  | 8                                |
 | `config.startHour`        | pod killing start time  in 24hr format              | 10                               |
 | `config.endHour`          | pod killing stop time  in 24hr format               | 16                               |


### PR DESCRIPTION
According to https://github.com/asobti/kube-monkey/blob/90c98321bb5d83d361c76168058398452388c340/helm/kubemonkey/values.yaml#L13

the default value of `dryRun` should be `true`