### PR TITLE
helm: support apps/v1

### DIFF
--- a/helm/kubemonkey/Chart.yaml
+++ b/helm/kubemonkey/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.3.0
 description: A Helm chart for Kubernetes
 name: kube-monkey
-version: 1.2
+version: 1.3

--- a/helm/kubemonkey/templates/deployment.yaml
+++ b/helm/kubemonkey/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "kubemonkey.fullname" . }}
@@ -32,7 +32,7 @@ spec:
           volumeMounts:
              - name: config-volume
                mountPath: "/etc/kube-monkey"
-      serviceAccountName: {{ template "kubemonkey.fullname" . }} 
+      serviceAccountName: {{ template "kubemonkey.fullname" . }}
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
`apps/v1beta2` no longer has `Deployment` in this year's Kubernetes deployments.