### PR TITLE
Spelling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ ifdef https_proxy
 docker_args+= --build-arg https_proxy=$(https_proxy)
 endif
 
-# Supressing docker build avoids printing the env variables
+# Suppressing docker build avoids printing the env variables
 container:
 	@echo "Running docker with '$(docker_args)'"
 	@docker build $(docker_args) -t kube-monkey:$(TAG) .

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -146,7 +146,7 @@ func (s *ConfigTestSuite) TestDebugForceShouldKill() {
 	s.True(DebugForceShouldKill())
 }
 
-func (s *ConfigTestSuite) TestDebugInmediateKill() {
+func (s *ConfigTestSuite) TestDebugImmediateKill() {
 	viper.Set(param.DebugScheduleImmediateKill, true)
 	s.True(DebugScheduleImmediateKill())
 }

--- a/config/param/param.go
+++ b/config/param/param.go
@@ -65,7 +65,7 @@ const (
 	// cluster APIServer. Use this config if the apiserver IP
 	// address provided by in-cluster config
 	// does not work for you because your certificate does not
-	// conatain the right SAN
+	// contain the right SAN
 	// Type: string
 	// Default: No default. If not specified, URL provided
 	// by in-cluster config is used

--- a/config/param/param.go
+++ b/config/param/param.go
@@ -52,7 +52,7 @@ const (
 	// Default: [ "default" ]
 	WhitelistedNamespaces = "kubemonkey.whitelisted_namespaces"
 
-	// BlacklistedNamespaces specifiesd a list of namespaces
+	// BlacklistedNamespaces specifies a list of namespaces
 	// for which terminations should never
 	// be carried out.
 	// Default is defined by metav1.NamespaceSystem

--- a/helm/kubemonkey/README.md
+++ b/helm/kubemonkey/README.md
@@ -49,7 +49,7 @@ $ helm install --name my-release kubemonkey \
 
 **Note: replace namespace with your real namespaces**
 
-If you want to see how kube-monkey kills pods immediatley in debug mode.
+If you want to see how kube-monkey kills pods immediately in debug mode.
 
 ```console
 $ helm install --name my-release kubemonkey \

--- a/helm/kubemonkey/README.md
+++ b/helm/kubemonkey/README.md
@@ -89,7 +89,7 @@ $ helm get manifest my-release
 | `config.whitelistedNamespaces`| pods in this namespace that opt-in will be killed|                                 |
 | `config.endHour.blacklistedNamespaces`| pods in this namespace will not be killed| kube-system                     |
 | `config.timeZone`         | time zone in DZ format                              | America/New_York                 |
-| `config.debug.enabled`    | debug mode,need to be enabled to see debuging behaviour| false                         |
+| `config.debug.enabled`    | debug mode, need to be enabled to see debugging behaviour| false                       |
 | `config.debug.schedule_immediate_kill` | immediate pod kill matching other rules apart from time| false            |
 | `args.logLevel`           | go log level                                        | 5                                |
 | `args.logDir`             | log directory                                       | /var/log/kube-monkey             |

--- a/helm/kubemonkey/README.md
+++ b/helm/kubemonkey/README.md
@@ -49,7 +49,7 @@ $ helm install --name my-release kubemonkey \
 
 **Note: replace namespace with your real namespaces**
 
-If you want to see how kube-monkey kills pods immediatley in debub mode.
+If you want to see how kube-monkey kills pods immediatley in debug mode.
 
 ```console
 $ helm install --name my-release kubemonkey \

--- a/helm/kubemonkey/README.md
+++ b/helm/kubemonkey/README.md
@@ -15,7 +15,7 @@ $ git clone https://github.com/asobti/kube-monkey
 $ cd kube-monkey/helm
 $ helm install --name my-release kubemonkey
 ```
-**Note:** by default kube-monkey installed in default namespace, which can be overriden by passing --namespace=name
+**Note:** by default kube-monkey installed in default namespace, which can be overridden by passing --namespace=name
 
 The command deploys kube-monkey on the Kubernetes cluster in the default configuration. The [configurations](#Configurations) section lists the parameters that can be configured during installation.
 

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -18,7 +18,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// CreateClient creates, verifes and returns an instance of k8 clientset
+// CreateClient creates, verifies and returns an instance of k8 clientset
 func CreateClient() (*kube.Clientset, error) {
 	client, err := NewInClusterClient()
 	if err != nil {

--- a/victims/factory/daemonsets/eligible_daemonsets_test.go
+++ b/victims/factory/daemonsets/eligible_daemonsets_test.go
@@ -40,7 +40,7 @@ func TestIsEnrolled(t *testing.T) {
 
 	b, _ := depl.IsEnrolled(client)
 
-	assert.Equal(t, b, true, "Expected daemoset to be enrolled")
+	assert.Equal(t, b, true, "Expected daemonset to be enrolled")
 }
 
 func TestIsNotEnrolled(t *testing.T) {

--- a/victims/factory/deployments/eligible_deployments_test.go
+++ b/victims/factory/deployments/eligible_deployments_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestEligibleDeployments(t *testing.T) {
-	v1deplepl := newDeployment(
+	v1depl := newDeployment(
 		NAME,
 		map[string]string{
 			"kube-monkey/identifier": "1",
@@ -18,14 +18,14 @@ func TestEligibleDeployments(t *testing.T) {
 		},
 	)
 
-	client := fake.NewSimpleClientset(&v1deplepl)
+	client := fake.NewSimpleClientset(&v1depl)
 	victims, _ := EligibleDeployments(client, NAMESPACE, &metav1.ListOptions{})
 
 	assert.Len(t, victims, 1)
 }
 
 func TestIsEnrolled(t *testing.T) {
-	v1deplepl := newDeployment(
+	v1depl := newDeployment(
 		NAME,
 		map[string]string{
 			config.IdentLabelKey:   "1",
@@ -34,9 +34,9 @@ func TestIsEnrolled(t *testing.T) {
 		},
 	)
 
-	depl, _ := New(&v1deplepl)
+	depl, _ := New(&v1depl)
 
-	client := fake.NewSimpleClientset(&v1deplepl)
+	client := fake.NewSimpleClientset(&v1depl)
 
 	b, _ := depl.IsEnrolled(client)
 
@@ -44,7 +44,7 @@ func TestIsEnrolled(t *testing.T) {
 }
 
 func TestIsNotEnrolled(t *testing.T) {
-	v1deplepl := newDeployment(
+	v1depl := newDeployment(
 		NAME,
 		map[string]string{
 			config.IdentLabelKey:   "1",
@@ -53,9 +53,9 @@ func TestIsNotEnrolled(t *testing.T) {
 		},
 	)
 
-	depl, _ := New(&v1deplepl)
+	depl, _ := New(&v1depl)
 
-	client := fake.NewSimpleClientset(&v1deplepl)
+	client := fake.NewSimpleClientset(&v1depl)
 
 	b, _ := depl.IsEnrolled(client)
 

--- a/victims/factory/statefulsets/eligible_statefulsets_test.go
+++ b/victims/factory/statefulsets/eligible_statefulsets_test.go
@@ -40,7 +40,7 @@ func TestIsEnrolled(t *testing.T) {
 
 	b, _ := stfs.IsEnrolled(client)
 
-	assert.Equal(t, b, true, "Expected stfsoyment to be enrolled")
+	assert.Equal(t, b, true, "Expected statefulset to be enrolled")
 }
 
 func TestIsNotEnrolled(t *testing.T) {
@@ -59,7 +59,7 @@ func TestIsNotEnrolled(t *testing.T) {
 
 	b, _ := stfs.IsEnrolled(client)
 
-	assert.Equal(t, b, false, "Expected stfsoyment to not be enrolled")
+	assert.Equal(t, b, false, "Expected statefulset to not be enrolled")
 }
 
 func TestKillType(t *testing.T) {


### PR DESCRIPTION
Misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

It reported: https://github.com/jsoref/kube-monkey/commit/66a194e5baca94a02df0fbcf86c860cc3cf4d759#commitcomment-39841266

And it validated that the changes in this PR made it *relatively* happy: https://github.com/jsoref/kube-monkey/commit/d6b2d5016666e67aa10a4cdeb4953fc4b8be3c83#commitcomment-39841269
(Relatively, as the remaining misspelling is subject to a different PR)

Note: this PR does not include the action, if you're interested, that can be offered separately.