### PR TITLE
Reload kubemonkey on configmap changes

### DIFF
--- a/helm/kubemonkey/Chart.yaml
+++ b/helm/kubemonkey/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.3.0
 description: A Helm chart for Kubernetes
 name: kube-monkey
-version: 1.3.0
+version: 1.3.2

--- a/helm/kubemonkey/templates/deployment.yaml
+++ b/helm/kubemonkey/templates/deployment.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         app: {{ template "kubemonkey.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+        checksum/config: "{{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}"
     spec:
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
### :pencil: Description
Reload kubemonkey on configmap changes (when using helm).
This will restart kubemonkey but that's preferable than continuing to use stale configurations.

Fixes #17
