### PR TITLE
Add github action for docker publishing

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -11,21 +11,32 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Go 1.15
-        uses: actions/setup-go@v2.1.2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
         with:
-          go-version: 1.15
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: Build
-        run: make test
+          # list of Docker images to use as base name for tags
+          images: |
+            ayushsobti/kubemonkey
+          # Generate Docker tags based on the following events/attributes
+          tags: |
+            type=ref,event=tag
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
-      - name: Build and push Docker images on new git tags
-        uses: docker/build-push-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
-          repository: ayushsobti/kubemonkey
-          tag_with_ref: true
-          tags: latest
-          push: ${{ startsWith(github.ref, 'refs/tags/') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -1,0 +1,31 @@
+name: Publish Docker image
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish-docker:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2.1.2
+        with:
+          go-version: 1.15
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Build
+        run: make test
+
+      - name: Build and push Docker images on new git tags
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          repository: ayushsobti/kubemonkey
+          tag_with_ref: true
+          tags: latest
+          push: ${{ startsWith(github.ref, 'refs/tags/') }}


### PR DESCRIPTION
### :pencil: Description

Automate build and publishing of docker image when a new tag is created.

@asobti when you have a chance, could you add a [token for Docker hub](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets)?

${{ secrets.DOCKER_HUB_USERNAME }}
${{ secrets.DOCKER_HUB_PASSWORD }}