### PR TITLE
Add the possibility to pass environment variable as header for the notification module

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.15
-      uses: actions/setup-go@v2.1.2
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: 1.15
     - name: Check out code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2.3.4
     - name: Build
       run: make test

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ headers = ["api-key:{$env:API_TOKEN}", "Content-Type:application/json"]
 
 `{$env:API_TOKEN}` will be replaced by the environment variable `API_TOKEN` value.
 
+Note if the environment variable does not exist, the notification call will NOT be cancelled. The value will be empty and we will add a warning in the logs. 
+
 ## Deploying
 
 **Manually**

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ headers = ["api-key:{$env:API_TOKEN}", "Content-Type:application/json"]
 
 `{$env:API_TOKEN}` will be replaced by the environment variable `API_TOKEN` value.
 
-Note if the environment variable does not exist, the notification call will NOT be cancelled. The value will be empty and we will add a warning in the logs. 
+Note if the environment variable does not exist, the notification call will NOT be cancelled. The value will resolve to an empty string, and a warning will show up in the logs. 
 
 ## Deploying
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ KUBEMONKEY_TIME_ZONE=America/New_York
 enabled= true
 schedule_immediate_kill= true
 ```
+
+## Notifications
+
+Kube-monkey supports notifications and can notify an endpoint of your choice after an attack.
+It can be a Slack webhook or a custom API.
+
 #### Example Config for posting attack notifications to an HTTP endpoint
 ```toml
 [notifications]
@@ -163,6 +169,34 @@ schedule_immediate_kill= true
     message = "message1"
     headers = ["header1Key:header1Value","header2Key:header2/Value"]
 ```
+
+#### Placeholders
+
+The message supports the following placeholders:
+* `{$name}`: victim's name
+* `{$kind}`: victim's kind
+* `{$namespace}`: victim's namespace
+* `{$timestamp}`: attack's time from Unix epoch in milliseconds
+* `{$date}`: attack's date
+* `{$error}`: result's error, if any
+
+```json
+  message: '{
+            "what": "Kube-monkey attack of {$name} in {$namespace}",
+            "who": "{$name}",
+            "when": {$timestamp}
+           }'
+```
+
+The header supports a special placeholder to retrieve the value of an environment variable.
+This is useful when calling an API that has a protected endpoint.
+A typical scenario will be to pass an API token to the Kube-monkey container, this token is stored in a Kubernetes Secret and you want to pass it via an environment variable.
+
+```json
+headers = ["api-key:{$env:API_TOKEN}", "Content-Type:application/json"]
+```
+
+`{$env:API_TOKEN}` will be replaced by the environment variable `API_TOKEN` value.
 
 ## Deploying
 

--- a/config/validations_test.go
+++ b/config/validations_test.go
@@ -48,6 +48,9 @@ func TestIsValidHeader(t *testing.T) {
 	header = "header1/Key:header1/Value"
 	assert.True(t, isValidHeader(header))
 
+	header = "header1:{$env:VARIABLE_NAME}"
+	assert.True(t, isValidHeader(header))
+
 	header = "header1Key"
 	assert.False(t, isValidHeader(header))
 

--- a/notifications/util.go
+++ b/notifications/util.go
@@ -33,12 +33,12 @@ func toHeaders(headersArray []string) map[string]string {
 			headersMap[strings.TrimSpace(kv[0])] = ""
 			continue
 		}
-		headersMap[strings.TrimSpace(kv[0])] = ReplaceEnvVariablePlaceholder(strings.TrimSpace(kv[1]))
+		headersMap[strings.TrimSpace(kv[0])] = replaceEnvVariablePlaceholder(strings.TrimSpace(kv[1]))
 	}
 	return headersMap
 }
 
-func ReplaceEnvVariablePlaceholder(value string) string {
+func replaceEnvVariablePlaceholder(value string) string {
 	envVariableRegex := regexp.MustCompile(EnvVariableRegex)
 	if envVariableRegex.MatchString(value) {
 		prefix, _ := envVariableRegex.LiteralPrefix()

--- a/notifications/util.go
+++ b/notifications/util.go
@@ -43,7 +43,11 @@ func ReplaceEnvVariablePlaceholder(value string) string {
 	if envVariableRegex.MatchString(value) {
 		prefix, _ := envVariableRegex.LiteralPrefix()
 		envVariableName := value[len(prefix) : len(value)-1]
-		value = envVariableRegex.ReplaceAllString(value, os.Getenv(envVariableName))
+		envVariableValue := os.Getenv(envVariableName)
+		if len(envVariableValue) == 0 {
+			glog.Errorf("Cannot find environment variable %s", envVariableName)
+		}
+		value = envVariableRegex.ReplaceAllString(value, envVariableValue)
 	}
 	return value
 }

--- a/notifications/util.go
+++ b/notifications/util.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// header
-	EnvVariableRegex = "^{\\$env:.*\\}$"
+	EnvVariableRegex = "^{\\$env:\\w+\\}$"
 
 	// body (message)
 	Name      = "{$name}"
@@ -41,7 +41,8 @@ func toHeaders(headersArray []string) map[string]string {
 func ReplaceEnvVariablePlaceholder(value string) string {
 	envVariableRegex := regexp.MustCompile(EnvVariableRegex)
 	if envVariableRegex.MatchString(value) {
-		envVariableName := value[6 : len(value)-1]
+		prefix, _ := envVariableRegex.LiteralPrefix()
+		envVariableName := value[len(prefix) : len(value)-1]
 		value = envVariableRegex.ReplaceAllString(value, os.Getenv(envVariableName))
 	}
 	return value

--- a/notifications/util_test.go
+++ b/notifications/util_test.go
@@ -38,6 +38,16 @@ func Test_ToHeadersEnvVariablePlaceholder(t *testing.T) {
 	assert.Equal(t, "123456", headers["api-key"])
 }
 
+func Test_ToHeadersEnvVariablePlaceholderNotExiting(t *testing.T) {
+	headersArray := []string{"Content-Type:application/json", "api-key:{$env:API_KEY}"}
+
+	headers := toHeaders(headersArray)
+
+	assert.Equal(t, 2, len(headers))
+	assert.Equal(t, "application/json", headers["Content-Type"])
+	assert.Equal(t, "", headers["api-key"])
+}
+
 func Test_NamePlaceholder(t *testing.T) {
 	msg := `{"name":"{$name}"}`
 	currentTime := time.Now()

--- a/notifications/util_test.go
+++ b/notifications/util_test.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -24,6 +25,17 @@ func Test_ToHeadersMultiple(t *testing.T) {
 	assert.Equal(t, 2, len(headers))
 	assert.Equal(t, "application/json", headers["Content-Type"])
 	assert.Equal(t, "localhost", headers["Host"])
+}
+
+func Test_ToHeadersEnvVariablePlaceholder(t *testing.T) {
+	headersArray := []string{"Content-Type:application/json", "api-key:{$env:API_KEY}"}
+	os.Setenv("API_KEY", "123456")
+
+	headers := toHeaders(headersArray)
+
+	assert.Equal(t, 2, len(headers))
+	assert.Equal(t, "application/json", headers["Content-Type"])
+	assert.Equal(t, "123456", headers["api-key"])
 }
 
 func Test_NamePlaceholder(t *testing.T) {

--- a/notifications/util_test.go
+++ b/notifications/util_test.go
@@ -38,7 +38,7 @@ func Test_ToHeadersEnvVariablePlaceholder(t *testing.T) {
 	assert.Equal(t, "123456", headers["api-key"])
 }
 
-func Test_ToHeadersEnvVariablePlaceholderNotExiting(t *testing.T) {
+func Test_ToHeadersEnvVariablePlaceholderNotExisting(t *testing.T) {
 	headersArray := []string{"Content-Type:application/json", "api-key:{$env:VARIABLE_NOT_SET}"}
 
 	headers := toHeaders(headersArray)

--- a/notifications/util_test.go
+++ b/notifications/util_test.go
@@ -39,7 +39,7 @@ func Test_ToHeadersEnvVariablePlaceholder(t *testing.T) {
 }
 
 func Test_ToHeadersEnvVariablePlaceholderNotExiting(t *testing.T) {
-	headersArray := []string{"Content-Type:application/json", "api-key:{$env:API_KEY}"}
+	headersArray := []string{"Content-Type:application/json", "api-key:{$env:VARIABLE_NOT_SET}"}
 
 	headers := toHeaders(headersArray)
 


### PR DESCRIPTION
### :pencil: Description

Add the possibility to pass an environment variable in an header value for the notification module.

This is useful when calling an API that has a protected endpoint.

A typical scenario is to pass an API token that is stored in a Kube secret and we want to pass it to the Kube monkey container via an environment variable.

```
headers = ["api-key:{$env:API_TOKEN}", "Content-Type:application/json"]
```
`{$env:API_TOKEN}` will be replaced by the environment variable `API_TOKEN` value.