### PR TITLE
notifications: Add new 'time' placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ The message supports the following placeholders:
 * `{$kind}`: victim's kind
 * `{$namespace}`: victim's namespace
 * `{$timestamp}`: attack's time from Unix epoch in milliseconds
+* `{$time}`: attack's time
 * `{$date}`: attack's date
 * `{$error}`: result's error, if any
 

--- a/notifications/util.go
+++ b/notifications/util.go
@@ -19,6 +19,7 @@ const (
 	Kind      = "{$kind}"
 	Namespace = "{$namespace}"
 	Timestamp = "{$timestamp}"
+	Time      = "{$time}"
 	Date      = "{$date}"
 	Error     = "{$error}"
 )
@@ -57,6 +58,7 @@ func ReplacePlaceholders(msg string, name string, kind string, namespace string,
 	msg = strings.Replace(msg, Kind, kind, -1)
 	msg = strings.Replace(msg, Namespace, namespace, -1)
 	msg = strings.Replace(msg, Timestamp, timeToEpoch(attackTime), -1)
+	msg = strings.Replace(msg, Time, timeToTime(attackTime), -1)
 	msg = strings.Replace(msg, Date, timeToDate(attackTime), -1)
 	msg = strings.Replace(msg, Error, err, -1)
 
@@ -71,4 +73,8 @@ func timeToEpoch(time time.Time) string {
 
 func timeToDate(time time.Time) string {
 	return time.Format("2006-01-02")
+}
+
+func timeToTime(time time.Time) string {
+	return time.Format("15:04:05 MST")
 }

--- a/notifications/util_test.go
+++ b/notifications/util_test.go
@@ -77,10 +77,17 @@ func Test_ErrorPlaceholder(t *testing.T) {
 }
 
 func Test_TimestampPlaceholder(t *testing.T) {
-	msg := `{"time":"{$timestamp}"}`
+	msg := `{"timestamp":"{$timestamp}"}`
 	currentTime := time.Now()
 	actual := ReplacePlaceholders(msg, "", "", "", "", currentTime)
-	assert.Equal(t, `{"time":"`+timeToEpoch(currentTime)+`"}`, actual)
+	assert.Equal(t, `{"timestamp":"`+timeToEpoch(currentTime)+`"}`, actual)
+}
+
+func Test_TimePlaceholder(t *testing.T) {
+	msg := `{"time":"{$time}"}`
+	currentTime := time.Now()
+	actual := ReplacePlaceholders(msg, "", "", "", "", currentTime)
+	assert.Equal(t, `{"time":"`+timeToTime(currentTime)+`"}`, actual)
 }
 
 func Test_DatePlaceholder(t *testing.T) {


### PR DESCRIPTION
### :pencil: Description

Add new 'time' placeholder to print the time in 24h format. This can be
helpful when paired with the $date placeholder in order to be able to
determine when the attack happened in human readable format instead of
using the milliseconds value from $timestamp.

* [x] Code is up-to-date with the `master` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.
