### PR TITLE
notifications: Add option to print attack schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ It can be a Slack webhook or a custom API.
 ```toml
 [notifications]
   enabled = true
+  reportSchedule = true
   [notifications.attacks]
     endpoint = "http://url1"
     message = "message1"

--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,7 @@ func SetDefaults() {
 	viper.SetDefault(param.DebugScheduleImmediateKill, false)
 
 	viper.SetDefault(param.NotificationsEnabled, false)
+	viper.SetDefault(param.NotificationsReportSchedule, false)
 	viper.SetDefault(param.NotificationsAttacks, Receiver{})
 }
 
@@ -178,6 +179,10 @@ func DebugScheduleImmediateKill() bool {
 
 func NotificationsEnabled() bool {
 	return viper.GetBool(param.NotificationsEnabled)
+}
+
+func NotificationsReportSchedule() bool {
+	return viper.GetBool(param.NotificationsReportSchedule)
 }
 
 func NotificationsAttacks() Receiver {

--- a/config/param/param.go
+++ b/config/param/param.go
@@ -104,6 +104,11 @@ const (
 	// Default: false
 	NotificationsEnabled = "notifications.enabled"
 
+	// NotificationsReportSchedule enables reporting of attack schedule to an HTTP endpoint
+	// Type: bool
+	// Default: false
+	NotificationsReportSchedule = "notifications.reportSchedule"
+
 	// NotificationsAttacks reports attacks to an HTTP endpoint
 	// Type: config.Receiver struct
 	// Default: Receiver{}

--- a/examples/notifications-configmap.yaml
+++ b/examples/notifications-configmap.yaml
@@ -17,6 +17,7 @@
         graceperiod_sec= 10
         [notifications]
           enabled = true
+          reportSchedule = true
           [notifications.attacks]
             endpoint = "test1"
             message = '''{"foo":"bar","bar":"foo"}'''

--- a/kubemonkey/kubemonkey.go
+++ b/kubemonkey/kubemonkey.go
@@ -49,6 +49,9 @@ func Run() error {
 			glog.Fatal(err.Error())
 		}
 		schedule.Print()
+		if config.NotificationsEnabled() && config.NotificationsReportSchedule() {
+			notifications.ReportSchedule(notificationsClient, schedule)
+		}
 		fmt.Println(schedule)
 		ScheduleTerminations(schedule.Entries(), notificationsClient)
 	}

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/asobti/kube-monkey/chaos"
 	"github.com/asobti/kube-monkey/config"
+	"github.com/asobti/kube-monkey/schedule"
 	"github.com/golang/glog"
 )
 
@@ -14,6 +15,20 @@ func Send(client Client, endpoint string, msg string, headers map[string]string)
 		return fmt.Errorf("send request: %v", err)
 	}
 	return nil
+}
+
+func ReportSchedule(client Client, schedule *schedule.Schedule) bool {
+	success := true
+	receiver := config.NotificationsAttacks()
+	msg := fmt.Sprintf("{\"text\": \"schedule:\n%s\n\"}", schedule)
+
+	glog.V(1).Infof("reporting next schedule")
+	if err := Send(client, receiver.Endpoint, msg, toHeaders(receiver.Headers)); err != nil {
+		glog.Errorf("error reporting next schedule")
+		success = false
+	}
+
+	return success
 }
 
 func ReportAttack(client Client, result *chaos.Result, time time.Time) bool {

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -10,6 +10,7 @@ import (
 	"bou.ke/monkey"
 	"github.com/asobti/kube-monkey/chaos"
 	"github.com/asobti/kube-monkey/config"
+	"github.com/asobti/kube-monkey/schedule"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -35,6 +36,23 @@ func (s *NotificationsTestSuite) SetupTest() {
 
 func (s *NotificationsTestSuite) TearDownTest() {
 	defer s.server.Close()
+}
+
+func (s *NotificationsTestSuite) TestReportSchedule() {
+	//mock Receiver
+	endpoint := s.server.URL + "/path"
+	receiver := config.NewReceiver(endpoint, "message", []string{"header1Key:header1Value", "header2Key:header2Value"})
+	monkey.Patch(config.NotificationsAttacks, func() config.Receiver { return receiver })
+	defer monkey.Unpatch(config.NotificationsAttacks)
+
+	sch := &schedule.Schedule{}
+	e1 := chaos.NewMock()
+	e2 := chaos.NewMock()
+	sch.Add(e1)
+	sch.Add(e2)
+
+	success := ReportSchedule(s.client, sch)
+	s.Assert().True(success)
 }
 
 func (s *NotificationsTestSuite) TestReportSuccessfulAttack() {


### PR DESCRIPTION
### :pencil: Description

Chaos experiments are meant to be controlled. As such, it's useful to
know the schedule that kube-monkey has created for us in order to know
beforehand when failures are to be expected.

Please verify that:
* [x] Code is up-to-date with the `master` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.
