### PR TITLE
notifications: Add new $kubemonkeyid placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,11 @@ The message supports the following placeholders:
 * `{$time}`: attack's time
 * `{$date}`: attack's date
 * `{$error}`: result's error, if any
+* `{$kubemonkeyid}`: kube-monkey id (set using KUBE_MONKEY_ID env variable otherwise empty)
 
 ```json
   message: '{
-            "what": "Kube-monkey attack of {$name} in {$namespace}",
+            "what": "Kube-monkey(${kubemonkeyid}) attack of {$name} in {$namespace}",
             "who": "{$name}",
             "when": {$timestamp}
            }'

--- a/examples/deployment.yaml
+++ b/examples/deployment.yaml
@@ -20,6 +20,9 @@
                - "/kube-monkey"
              args: ["-v=5", "-log_dir=/var/log/kube-monkey"]
              image: ayushsobti/kube-monkey:v0.3.0
+             env:
+               - name: KUBE_MONKEY_ID
+                 value: CLUSTER_A
              volumeMounts:
                - name: config-volume
                  mountPath: "/etc/kube-monkey"

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/asobti/kube-monkey/chaos"
@@ -20,7 +21,8 @@ func Send(client Client, endpoint string, msg string, headers map[string]string)
 func ReportSchedule(client Client, schedule *schedule.Schedule) bool {
 	success := true
 	receiver := config.NotificationsAttacks()
-	msg := fmt.Sprintf("{\"text\": \"schedule:\n%s\n\"}", schedule)
+
+	msg := fmt.Sprintf("{\"text\": \"\n%s\n\"}", schedule)
 
 	glog.V(1).Infof("reporting next schedule")
 	if err := Send(client, receiver.Endpoint, msg, toHeaders(receiver.Headers)); err != nil {
@@ -39,7 +41,7 @@ func ReportAttack(client Client, result *chaos.Result, time time.Time) bool {
 	if result.Error() != nil {
 		errorString = result.Error().Error()
 	}
-	msg := ReplacePlaceholders(receiver.Message, result.Victim().Name(), result.Victim().Kind(), result.Victim().Namespace(), errorString, time)
+	msg := ReplacePlaceholders(receiver.Message, result.Victim().Name(), result.Victim().Kind(), result.Victim().Namespace(), errorString, time, os.Getenv("KUBE_MONKEY_ID"))
 	glog.V(1).Infof("reporting attack for %s %s to %s with message %s\n", result.Victim().Kind(), result.Victim().Name(), receiver.Endpoint, msg)
 	if err := Send(client, receiver.Endpoint, msg, toHeaders(receiver.Headers)); err != nil {
 		glog.Errorf("error reporting attack for %s %s to %s with message %s, error: %v\n", result.Victim().Kind(), result.Victim().Name(), receiver.Endpoint, msg, err)

--- a/notifications/util.go
+++ b/notifications/util.go
@@ -15,13 +15,14 @@ const (
 	EnvVariableRegex = "^{\\$env:\\w+\\}$"
 
 	// body (message)
-	Name      = "{$name}"
-	Kind      = "{$kind}"
-	Namespace = "{$namespace}"
-	Timestamp = "{$timestamp}"
-	Time      = "{$time}"
-	Date      = "{$date}"
-	Error     = "{$error}"
+	Name         = "{$name}"
+	Kind         = "{$kind}"
+	Namespace    = "{$namespace}"
+	Timestamp    = "{$timestamp}"
+	Time         = "{$time}"
+	Date         = "{$date}"
+	Error        = "{$error}"
+	KubeMonkeyID = "{$kubemonkeyid}"
 )
 
 func toHeaders(headersArray []string) map[string]string {
@@ -53,7 +54,7 @@ func replaceEnvVariablePlaceholder(value string) string {
 	return value
 }
 
-func ReplacePlaceholders(msg string, name string, kind string, namespace string, err string, attackTime time.Time) string {
+func ReplacePlaceholders(msg string, name string, kind string, namespace string, err string, attackTime time.Time, kubeMonkeyID string) string {
 	msg = strings.Replace(msg, Name, name, -1)
 	msg = strings.Replace(msg, Kind, kind, -1)
 	msg = strings.Replace(msg, Namespace, namespace, -1)
@@ -61,6 +62,7 @@ func ReplacePlaceholders(msg string, name string, kind string, namespace string,
 	msg = strings.Replace(msg, Time, timeToTime(attackTime), -1)
 	msg = strings.Replace(msg, Date, timeToDate(attackTime), -1)
 	msg = strings.Replace(msg, Error, err, -1)
+	msg = strings.Replace(msg, KubeMonkeyID, kubeMonkeyID, -1)
 
 	return msg
 }

--- a/notifications/util_test.go
+++ b/notifications/util_test.go
@@ -51,55 +51,62 @@ func Test_ToHeadersEnvVariablePlaceholderNotExisting(t *testing.T) {
 func Test_NamePlaceholder(t *testing.T) {
 	msg := `{"name":"{$name}"}`
 	currentTime := time.Now()
-	actual := ReplacePlaceholders(msg, "testName", "", "", "", currentTime)
+	actual := ReplacePlaceholders(msg, "testName", "", "", "", currentTime, "CLUSTER_A")
 	assert.Equal(t, `{"name":"testName"}`, actual)
 }
 
 func Test_KindPlaceholder(t *testing.T) {
 	msg := `{"kind":"{$kind}"}`
 	currentTime := time.Now()
-	actual := ReplacePlaceholders(msg, "", "testKind", "", "", currentTime)
+	actual := ReplacePlaceholders(msg, "", "testKind", "", "", currentTime, "CLUSTER_A")
 	assert.Equal(t, `{"kind":"testKind"}`, actual)
 }
 
 func Test_NamespacePlaceholder(t *testing.T) {
 	msg := `{"namespace":"{$namespace}"}`
 	currentTime := time.Now()
-	actual := ReplacePlaceholders(msg, "", "", "testNamespace", "", currentTime)
+	actual := ReplacePlaceholders(msg, "", "", "testNamespace", "", currentTime, "CLUSTER_A")
 	assert.Equal(t, `{"namespace":"testNamespace"}`, actual)
 }
 
 func Test_ErrorPlaceholder(t *testing.T) {
 	msg := `{"error":"{$error}"}`
 	currentTime := time.Now()
-	actual := ReplacePlaceholders(msg, "", "", "", "testError", currentTime)
+	actual := ReplacePlaceholders(msg, "", "", "", "testError", currentTime, "CLUSTER_A")
 	assert.Equal(t, `{"error":"testError"}`, actual)
+}
+
+func Test_IDPlaceholder(t *testing.T) {
+	msg := `{"kubemonkeyid":"{$kubemonkeyid}"}`
+	currentTime := time.Now()
+	actual := ReplacePlaceholders(msg, "", "", "", "testError", currentTime, "CLUSTER_A")
+	assert.Equal(t, `{"kubemonkeyid":"CLUSTER_A"}`, actual)
 }
 
 func Test_TimestampPlaceholder(t *testing.T) {
 	msg := `{"timestamp":"{$timestamp}"}`
 	currentTime := time.Now()
-	actual := ReplacePlaceholders(msg, "", "", "", "", currentTime)
+	actual := ReplacePlaceholders(msg, "", "", "", "", currentTime, "CLUSTER_A")
 	assert.Equal(t, `{"timestamp":"`+timeToEpoch(currentTime)+`"}`, actual)
 }
 
 func Test_TimePlaceholder(t *testing.T) {
 	msg := `{"time":"{$time}"}`
 	currentTime := time.Now()
-	actual := ReplacePlaceholders(msg, "", "", "", "", currentTime)
+	actual := ReplacePlaceholders(msg, "", "", "", "", currentTime, "CLUSTER_A")
 	assert.Equal(t, `{"time":"`+timeToTime(currentTime)+`"}`, actual)
 }
 
 func Test_DatePlaceholder(t *testing.T) {
 	msg := `{"date":"{$date}"}`
 	currentTime := time.Now()
-	actual := ReplacePlaceholders(msg, "", "", "", "", currentTime)
+	actual := ReplacePlaceholders(msg, "", "", "", "", currentTime, "CLUSTER_A")
 	assert.Equal(t, `{"date":"`+timeToDate(currentTime)+`"}`, actual)
 }
 
 func Test_MultiplePlaceholders(t *testing.T) {
 	msg := `{"date1":"{$date}","date2":"{$date}","name":"{$name}"}`
 	currentTime := time.Now()
-	actual := ReplacePlaceholders(msg, "testName", "", "", "", currentTime)
+	actual := ReplacePlaceholders(msg, "testName", "", "", "", currentTime, "CLUSTER_A")
 	assert.Equal(t, `{"date1":"`+timeToDate(currentTime)+`","date2":"`+timeToDate(currentTime)+`","name":"testName"}`, actual)
 }

--- a/schedule/schedule.go
+++ b/schedule/schedule.go
@@ -3,6 +3,7 @@ package schedule
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"strings"
 	"time"
 
@@ -16,7 +17,8 @@ import (
 
 const (
 	Today         = "\t********** Today's schedule **********"
-	NoTermination = "No terminations scheduled"
+	KubeMonkeyID  = "\tKubeMonkey ID: %s"
+	NoTermination = "\tNo terminations scheduled"
 	HeaderRow     = "\tk8 Api Kind\tKind Namespace\tKind Name\t\tTermination Time"
 	SepRow        = "\t-----------\t--------------\t---------\t\t----------------"
 	RowFormat     = "\t%s\t%s\t%s\t\t%s"
@@ -38,7 +40,14 @@ func (s *Schedule) Add(entry *chaos.Chaos) {
 
 func (s *Schedule) String() string {
 	schedString := []string{}
+
 	schedString = append(schedString, fmt.Sprint(Today))
+
+	kubeMonkeyID := os.Getenv("KUBE_MONKEY_ID")
+	if kubeMonkeyID != "" {
+		schedString = append(schedString, fmt.Sprintf(KubeMonkeyID, kubeMonkeyID))
+	}
+
 	if len(s.entries) == 0 {
 		schedString = append(schedString, fmt.Sprint(NoTermination))
 	} else {

--- a/schedule/schedule_test.go
+++ b/schedule/schedule_test.go
@@ -2,6 +2,7 @@ package schedule
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -38,10 +39,30 @@ func TestStringNoEntries(t *testing.T) {
 
 	schedString := []string{}
 	schedString = append(schedString, fmt.Sprint(Today))
+
 	schedString = append(schedString, fmt.Sprint(NoTermination))
 	schedString = append(schedString, fmt.Sprint(End))
 
 	assert.Equal(t, strings.Join(schedString, "\n"), s.String())
+}
+
+func TestStringNoEntriesWithID(t *testing.T) {
+
+	id := "TestingID"
+	os.Setenv("KUBE_MONKEY_ID", id)
+
+	s := newSchedule()
+
+	schedString := []string{}
+	schedString = append(schedString, fmt.Sprint(Today))
+	schedString = append(schedString, fmt.Sprintf(KubeMonkeyID, id))
+
+	schedString = append(schedString, fmt.Sprint(NoTermination))
+	schedString = append(schedString, fmt.Sprint(End))
+
+	assert.Equal(t, strings.Join(schedString, "\n"), s.String())
+
+	os.Unsetenv("KUBE_MONKEY_ID")
 }
 
 func TestStringWithEntries(t *testing.T) {


### PR DESCRIPTION
### :pencil: Description

Sometimes it's possible to run kube-monkey on multiple clusters
but all of them are sending notification so the same endpoint. In order
cases, we may run difference instances of kube-monkey on the same
cluster. It's useful to be able to identify the schedules and
notifications attacks and be able to correlate them with a particular
kube-monkey instance. As such, a new $id placeholder is added which
takes its value from the KUBE_MONKEY_ID env variable.

Please verify that:
* [x] Code is up-to-date with the `master` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.
