### PR TITLE
notifications: Add proxy for notifications request client

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -69,6 +69,7 @@ func SetDefaults() {
 	viper.SetDefault(param.DebugScheduleImmediateKill, false)
 
 	viper.SetDefault(param.NotificationsEnabled, false)
+	viper.SetDefault(param.NotificationsProxy, "")
 	viper.SetDefault(param.NotificationsReportSchedule, false)
 	viper.SetDefault(param.NotificationsAttacks, Receiver{})
 }
@@ -179,6 +180,10 @@ func DebugScheduleImmediateKill() bool {
 
 func NotificationsEnabled() bool {
 	return viper.GetBool(param.NotificationsEnabled)
+}
+
+func NotificationsProxy() string {
+	return viper.GetString(param.NotificationsProxy)
 }
 
 func NotificationsReportSchedule() bool {

--- a/config/config.go
+++ b/config/config.go
@@ -69,7 +69,7 @@ func SetDefaults() {
 	viper.SetDefault(param.DebugScheduleImmediateKill, false)
 
 	viper.SetDefault(param.NotificationsEnabled, false)
-	viper.SetDefault(param.NotificationsProxy, "")
+	viper.SetDefault(param.NotificationsProxy, nil)
 	viper.SetDefault(param.NotificationsReportSchedule, false)
 	viper.SetDefault(param.NotificationsAttacks, Receiver{})
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -157,6 +157,12 @@ func (s *ConfigTestSuite) TestNotificationsEnabled() {
 	s.True(NotificationsEnabled())
 }
 
+func (s *ConfigTestSuite) TestNotificationsProxy() {
+	viper.Set(param.NotificationsProxy, "http://127.0.0.1:8080")
+	proxy := NotificationsProxy()
+	s.Equal("http://127.0.0.1:8080", proxy)
+}
+
 func (s *ConfigTestSuite) TestNotificationsAttacks() {
 	headers := []string{"header1Key:header1Value", "header2Key:header2Value"}
 	receiver := map[string]interface{}{"endpoint": "endpoint1", "message": "message1", "headers": headers}

--- a/config/param/param.go
+++ b/config/param/param.go
@@ -106,7 +106,7 @@ const (
 
 	// Notifications Proxy enables send the request with proxy
 	// Type: string
-	// Default: ""
+	// Default: nil
 	NotificationsProxy = "notifications.proxy"
 
 	// NotificationsReportSchedule enables reporting of attack schedule to an HTTP endpoint

--- a/config/param/param.go
+++ b/config/param/param.go
@@ -104,6 +104,11 @@ const (
 	// Default: false
 	NotificationsEnabled = "notifications.enabled"
 
+	// Notifications Proxy enables send the request with proxy
+	// Type: string
+	// Default: ""
+	NotificationsProxy = "notifications.proxy"
+
 	// NotificationsReportSchedule enables reporting of attack schedule to an HTTP endpoint
 	// Type: bool
 	// Default: false

--- a/examples/notifications-configmap.yaml
+++ b/examples/notifications-configmap.yaml
@@ -17,7 +17,7 @@
         graceperiod_sec= 10
         [notifications]
           enabled = true
-          proxy = ""
+          proxy = "host:port"
           reportSchedule = true
           [notifications.attacks]
             endpoint = "test1"

--- a/examples/notifications-configmap.yaml
+++ b/examples/notifications-configmap.yaml
@@ -17,6 +17,7 @@
         graceperiod_sec= 10
         [notifications]
           enabled = true
+          proxy = ""
           reportSchedule = true
           [notifications.attacks]
             endpoint = "test1"

--- a/kubemonkey/kubemonkey.go
+++ b/kubemonkey/kubemonkey.go
@@ -38,7 +38,7 @@ func Run() error {
 		glog.V(1).Infof("Notifications enabled!")
 		proxy := config.NotificationsProxy()
 		glog.V(1).Infof("Notifications proxy %s!", proxy)
-		notificationsClient = notifications.CreateClient(proxy)
+		notificationsClient = notifications.CreateClient(&proxy)
 	}
 
 	for {

--- a/kubemonkey/kubemonkey.go
+++ b/kubemonkey/kubemonkey.go
@@ -36,7 +36,9 @@ func Run() error {
 	var notificationsClient notifications.Client
 	if config.NotificationsEnabled() {
 		glog.V(1).Infof("Notifications enabled!")
-		notificationsClient = notifications.CreateClient()
+		proxy := config.NotificationsProxy()
+		glog.V(1).Infof("Notifications proxy %s!", proxy)
+		notificationsClient = notifications.CreateClient(proxy)
 	}
 
 	for {

--- a/notifications/client.go
+++ b/notifications/client.go
@@ -17,7 +17,7 @@ type Client struct {
 }
 
 // CreateClient creates a new client with a default timeout
-func CreateClient(proxy string) Client {
+func CreateClient(proxy *string) Client {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
@@ -25,8 +25,8 @@ func CreateClient(proxy string) Client {
 	transport := http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
-	if proxy != "" {
-		proxyUrl, _ := url.Parse(proxy)
+	if proxy != nil {
+		proxyUrl, _ := url.Parse(*proxy)
 		transport.Proxy = http.ProxyURL(proxyUrl)
 	}
 	client.Transport = &transport

--- a/notifications/client.go
+++ b/notifications/client.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -16,14 +17,19 @@ type Client struct {
 }
 
 // CreateClient creates a new client with a default timeout
-func CreateClient() Client {
+func CreateClient(proxy string) Client {
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
 
-	client.Transport = &http.Transport{
+	transport := http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
+	if proxy != "" {
+		proxyUrl, _ := url.Parse(proxy)
+		transport.Proxy = http.ProxyURL(proxyUrl)
+	}
+	client.Transport = &transport
 	return Client{httpClient: client}
 }
 

--- a/notifications/client_test.go
+++ b/notifications/client_test.go
@@ -16,7 +16,7 @@ func TestRequestSuccess(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := CreateClient("")
+	c := CreateClient(nil)
 	body := "message"
 	err := c.Request(server.URL+path, body, map[string]string{})
 	if err != nil {
@@ -31,7 +31,7 @@ func TestRequestFails(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := CreateClient("")
+	c := CreateClient(nil)
 	body := ""
 	err := c.Request(server.URL, body, map[string]string{})
 	expectedErr := fmt.Sprintf("POST %s returned 403 Unauthorized, expected 2xx", server.URL)

--- a/notifications/client_test.go
+++ b/notifications/client_test.go
@@ -16,7 +16,7 @@ func TestRequestSuccess(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := CreateClient()
+	c := CreateClient("")
 	body := "message"
 	err := c.Request(server.URL+path, body, map[string]string{})
 	if err != nil {
@@ -31,7 +31,7 @@ func TestRequestFails(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := CreateClient()
+	c := CreateClient("")
 	body := ""
 	err := c.Request(server.URL, body, map[string]string{})
 	expectedErr := fmt.Sprintf("POST %s returned 403 Unauthorized, expected 2xx", server.URL)

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -24,7 +24,7 @@ type NotificationsTestSuite struct {
 
 func (s *NotificationsTestSuite) SetupTest() {
 	//create HTTP client
-	s.client = CreateClient("")
+	s.client = CreateClient(nil)
 	//start server
 	s.server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {}))
 	//create Result

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -24,7 +24,7 @@ type NotificationsTestSuite struct {
 
 func (s *NotificationsTestSuite) SetupTest() {
 	//create HTTP client
-	s.client = CreateClient()
+	s.client = CreateClient("")
 	//start server
 	s.server = httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {}))
 	//create Result


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/asobti/kube-monkey/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
read http proxy from config.toml for notifications request client

### :link: Related Issues
