### PR TITLE
Notifications should work without http proxy set

### DIFF
--- a/kubemonkey/kubemonkey.go
+++ b/kubemonkey/kubemonkey.go
@@ -37,7 +37,9 @@ func Run() error {
 	if config.NotificationsEnabled() {
 		glog.V(1).Infof("Notifications enabled!")
 		proxy := config.NotificationsProxy()
-		glog.V(1).Infof("Notifications proxy %s!", proxy)
+		if proxy != "" {
+			glog.V(1).Infof("Notifications proxy set: %s!", proxy)
+		}
 		notificationsClient = notifications.CreateClient(&proxy)
 	}
 

--- a/notifications/client.go
+++ b/notifications/client.go
@@ -25,7 +25,7 @@ func CreateClient(proxy *string) Client {
 	transport := http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
-	if proxy != nil {
+	if proxy != nil && *proxy != "" {
 		proxyUrl, _ := url.Parse(*proxy)
 		transport.Proxy = http.ProxyURL(proxyUrl)
 	}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [v] Code is up-to-date with the `master` branch.
* [v] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/asobti/kube-monkey/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
Before this change when proxy was not set in config, sending notification resulted in notification error: `proxyconnect tcp: dial tcp :0: connect: connection refused`

### :link: Related Issues
none, found bug & fixed :)