### PR TITLE
Don't include whitelisted_namespaces in config when empty

### DIFF
--- a/helm/kubemonkey/templates/configmap.yaml
+++ b/helm/kubemonkey/templates/configmap.yaml
@@ -11,7 +11,10 @@ data:
       start_hour = {{ .Values.config.startHour }}
       end_hour = {{ .Values.config.endHour }}
       blacklisted_namespaces = [ {{- range .Values.config.blacklistedNamespaces }} {{ . | trim | quote }}, {{- end }} ]
+      {{- $whitelen := len .Values.config.whitelistedNamespaces }}
+      {{- if gt $whitelen 0 }}
       whitelisted_namespaces = [ {{- range .Values.config.whitelistedNamespaces }} {{ . | trim | quote }}, {{- end }} ]
+      {{- end }}
       time_zone = {{ .Values.config.timeZone | quote }}
       [debug]
       enabled= {{ .Values.config.debug.enabled }}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [v] Code is up-to-date with the `master` branch.
* [v] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/asobti/kube-monkey/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
Chart always included `whitelisted_namespaces` in config.toml, which resulted in empty list of whitelisted namespaces.
With such config I couldn't include all namespace by default.

### :link: Related Issues
none