### PR TITLE
Use latest chart version

### DIFF
--- a/helm/kubemonkey/README.md
+++ b/helm/kubemonkey/README.md
@@ -16,13 +16,13 @@ To install the chart with the release name `my-release`:
 With Helm v3
 
 ```bash
-helm install my-release kubemonkey/kube-monkey --version 1.4.0
+helm install my-release kubemonkey/kube-monkey --version 1.5.0
 ```
 
 With Helm v2
 
 ```bash
-helm install --name my-release kubemonkey/kube-monkey --version 1.4.0
+helm install --name my-release kubemonkey/kube-monkey --version 1.5.0
 ```
 
 The command deploys kube-monkey on the Kubernetes cluster in the default configuration. The [configurations](#Configurations) section lists the parameters that can be configured during installation.


### PR DESCRIPTION
This will avoid errors like:
```
no matches for kind "ClusterRoleBinding" in version "rbac.authorization.k8s.io/v1beta1"
```
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] Code is up-to-date with the `master` branch.
* [x] You've successfully built and run the tests locally.
* [x] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/asobti/kube-monkey/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
Use the latest version of the helm chart on the readme.

### :link: Related Issues
