### PR TITLE
Add round for killNum

### DIFF
--- a/internal/pkg/victims/victims.go
+++ b/internal/pkg/victims/victims.go
@@ -281,7 +281,7 @@ func (v *VictimBase) KillNumberForFixedPercentage(clientset kube.Interface, kill
 	}
 
 	numberOfPodsToKill := float64(numRunningPods) * float64(killPercentage) / 100
-	killNum := int(math.Floor(numberOfPodsToKill))
+	killNum := int(math.Round(numberOfPodsToKill))
 
 	return killNum, nil
 }
@@ -305,7 +305,7 @@ func (v *VictimBase) KillNumberForMaxPercentage(clientset kube.Interface, maxPer
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	killPercentage := r.Intn(maxPercentage + 1) // + 1 because Intn works with half open interval [0,n) and we want [0,n]
 	numberOfPodsToKill := float64(numRunningPods) * float64(killPercentage) / 100
-	killNum := int(math.Floor(numberOfPodsToKill))
+	killNum := int(math.Round(numberOfPodsToKill))
 
 	return killNum, nil
 }

--- a/internal/pkg/victims/victims_test.go
+++ b/internal/pkg/victims/victims_test.go
@@ -258,7 +258,7 @@ func TestDeletePodsFixedPercentage(t *testing.T) {
 			pods: append(
 				generateNPods("running", 1, corev1.PodRunning),
 				generateNPods("pending", 1, corev1.PodPending)...),
-			expectedNum: 0,
+			expectedNum: 1,
 			expectedErr: false,
 		},
 	}


### PR DESCRIPTION
To kill at least one pod if the replicaSet is above 2 replicas.
It correct this issue:  https://github.com/asobti/kube-monkey/issues/227

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `master` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/asobti/kube-monkey/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
To kill at least one pod if the replicaSet is above 2 replicas.

### :link: Related Issues
It correct this issue:  https://github.com/asobti/kube-monkey/issues/227
