### PR TITLE
Added new ClusterRole and updated ClusterRoleBinding for RBAC

### DIFF
--- a/helm/kubemonkey/templates/rbac.yaml
+++ b/helm/kubemonkey/templates/rbac.yaml
@@ -12,6 +12,52 @@ metadata:
 
 ---
 
+---
+
+{{- if .Values.rbac.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "kubemonkey.fullname" . }}
+rules:
+- apiGroups:
+  - ""
+  - "extensions"
+  - "apps"
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  - replicasets
+  - replicasets/scale
+  - statefulsets
+  - statefulsets/scale
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: 
+  - ""
+  resources: 
+  - "namespaces"
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - "pods"
+  verbs:
+  - "get"
+  - "list"
+  - "watch"
+  - "delete"
+{{- end}}
+
+---
+
 {{- if .Values.rbac.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -21,7 +67,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: edit
+  name: {{ template "kubemonkey.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubemonkey.serviceAccountName" . }}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `master` branch.
* [X] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/asobti/kube-monkey/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
Wanted to reduce the amount of RBAC permissions that are given to kube-monkey for security reasons. Currently, when RBAC is enabled through the Helm chart, kube-monkey is given permissions of the default Kubernetes ClusterRole `edit` which has [quite extensive permissions](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles) over resources that kube-monkey does not need such as accessing secrets. Hence, this feature adds a new more restricted ClusterRole that only has the `delete` permission for pods, and only read permissions for Kubernetes `apps` (e.g. deployments). 


### :link: Related Issues
The following issue is quite old but was used as a starting point for how the ClusterRole could be configured with limited permissions: https://github.com/asobti/kube-monkey/issues/22 
