### PR TITLE
Feature/helm more values config

### DIFF
--- a/helm/kubemonkey/templates/deployment.yaml
+++ b/helm/kubemonkey/templates/deployment.yaml
@@ -25,18 +25,26 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
-             - "/kube-monkey"
+            - "/kube-monkey"
           args: ["-v={{ .Values.args.logLevel }}", "-log_dir={{ .Values.args.logDir }}"]
           resources:
 {{- toYaml .Values.resources | trimSuffix "\n" | nindent 12 }}
           volumeMounts:
-             - name: config-volume
-               mountPath: "/etc/kube-monkey"
+            - name: config-volume
+              mountPath: "/etc/kube-monkey"
+            {{- if .Values.additionalVolumeMounts }}
+{{- toYaml .Values.additionalVolumeMounts | default "" | nindent 12 }}
+            {{- end}}
+      securityContext:
+{{- toYaml .Values.podSecurityContext | trimSuffix "\n" | nindent 8 }}
       serviceAccountName: {{ include "kubemonkey.serviceAccountName" . }}
       volumes:
         - name: config-volume
           configMap:
             name: {{ template "kubemonkey.fullname" . }}
+        {{- if .Values.additionalVolumes }}
+{{- toYaml .Values.additionalVolumes | default "" | nindent 8 }}
+        {{- end}}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
     {{ toYaml . | indent 8 }}

--- a/helm/kubemonkey/values.yaml
+++ b/helm/kubemonkey/values.yaml
@@ -55,3 +55,17 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+additionalVolumes: {}
+# - name: log
+#   emptyDir: {}
+
+additionalVolumeMounts: {}
+# - name: log
+#   mountPath: "/var/log"
+
+podSecurityContext: {}
+  # runAsNonRoot: true
+  # runAsUser: 1001
+  # runAsGroup: 1001
+  # fsGroup: 1001


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [X] Code is up-to-date with the `master` branch.
* [X] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
  https://github.com/asobti/kube-monkey/blob/master/CONTRIBUTING.md
-->

### :pencil: Description
Added more configuration options when deploying with the Helm chart. For example, I wanted `SecurityContext` to be configurable to be able to run the container as a different user than root and I also wanted to be able to mount a volume to use for logs. The default `values.yaml` file is configured as such that there are no changes from how it was previously. Also fixed some indentation in `deployment.yaml` file.

### :link: Related Issues
