### PR TITLE
Drop ioutil package.

### DIFF
--- a/internal/pkg/notifications/client.go
+++ b/internal/pkg/notifications/client.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -53,12 +52,12 @@ func (c Client) Request(endpoint string, requestBody string, headers map[string]
 	defer resp.Body.Close()
 
 	if resp.StatusCode/100 != 2 {
-		b, _ := ioutil.ReadAll(resp.Body) // try to read response body as well to give user more info why request failed
+		b, _ := io.ReadAll(resp.Body) // try to read response body as well to give user more info why request failed
 		return fmt.Errorf("%s %s returned %d %s, expected 2xx",
 			"POST", endpoint, resp.StatusCode, strings.TrimSuffix(string(b), "\n"))
 	}
 
-	if _, err = io.Copy(ioutil.Discard, resp.Body); err != nil {
+	if _, err = io.Copy(io.Discard, resp.Body); err != nil {
 		return fmt.Errorf("read response body: %s %s: %v", "POST", endpoint, err)
 	}
 	return nil


### PR DESCRIPTION
### :pencil: Description
Drop ioutil package. 
As it is deprecation , and can be replaced well.

```
Deprecated: As of Go 1.16, the same functionality is now 
provided by package [io](https://pkg.go.dev/io) 
or package [os](https://pkg.go.dev/os), 
and those implementations should be preferred in new code
```


### :link: Related Issues
