### PR TITLE
Extend mtbf time range to also support hours and minutes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ kube-monkey works on an opt-in model and will only schedule terminations for Kub
 Opt-in is done by setting the following labels on a k8s app:
 
 **`kube-monkey/enabled`**: Set to **`"enabled"`** to opt-in to kube-monkey  
-**`kube-monkey/mtbf`**: Mean time between failure (in days). For example, if set to **`"3"`**, the k8s app can expect to have a Pod
+**`kube-monkey/mtbf`**: Mean time between failure. Examples are: 1 or 1d (1 day), 4h (4 hours) and 20m (20 minutes). A recommended value would be 2h or 3h so pods get killed at least a couple of times a day.
 killed approximately every third weekday.  
 **`kube-monkey/identifier`**: A unique identifier for the k8s apps. This is used to identify the pods
 that belong to a k8s app as Pods inherit labels from their k8s app. So, if kube-monkey detects that app `foo` has enrolled to be a victim, kube-monkey will look for all pods that have the label `kube-monkey/identifier: foo` to determine which pods are candidates for killing. The recommendation is to set this value to be the same as the app's name.  
@@ -41,7 +41,7 @@ that belong to a k8s app as Pods inherit labels from their k8s app. So, if kube-
 * if `random-max-percent`, provide a number from `0`-`100` to specify the max `%` of pods kube-monkey can kill
 * if `fixed-percent`, provide a number from `0`-`100` to specify the `%` of pods to kill
 
-#### Example of opted-in Deployment killing one pod per purge
+#### Example of opted-in Deployment killing one pod once every two hours.
 
 ```yaml
 ---
@@ -56,7 +56,7 @@ spec:
       labels:
         kube-monkey/enabled: enabled
         kube-monkey/identifier: monkey-victim
-        kube-monkey/mtbf: '2'
+        kube-monkey/mtbf: '2h'
         kube-monkey/kill-mode: "fixed"
         kube-monkey/kill-value: '1'
 [... omitted ...]
@@ -74,7 +74,7 @@ metadata:
   labels:
     kube-monkey/enabled: enabled
     kube-monkey/identifier: monkey-victim
-    kube-monkey/mtbf: '2'
+    kube-monkey/mtbf: '2h'
     kube-monkey/kill-mode: "fixed"
     kube-monkey/kill-value: '1'
 spec:

--- a/internal/pkg/calendar/calendar.go
+++ b/internal/pkg/calendar/calendar.go
@@ -1,7 +1,11 @@
 package calendar
 
 import (
+	"errors"
+	"fmt"
 	"math/rand"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -49,19 +53,90 @@ func NextRuntime(loc *time.Location, r int) time.Time {
 	return time.Date(year, month, day, r, 0, 0, 0, loc)
 }
 
+// ParseMtbf parses an mtbf value and returns a valid time duration.
+func ParseMtbf(mtbf string) (time.Duration, error) {
+	// time.Duration biggest valid time unit is an hour, but we want to accept
+	// days. Before finer grained time units this software used to accept mtbf as
+	// an integer interpreted as days. Hence this routine now accepts a "d" as a
+	// valid time unit meaning days and simply strips it, because...
+	if mtbf[len(mtbf) - 1] == 'd' {
+		mtbf = strings.TrimRight(mtbf, "d")
+	}
+	// ...below we check if a given mtbf is simply a number and backward
+	// compatibilty dictates us to accept a simpel number as days (see above) and
+	// since time.Duration does not accept hours as a valid time unit we convert
+	// here ourselves days into hours.
+	if converted_mtbf, err := strconv.Atoi(mtbf); err == nil {
+		mtbf = fmt.Sprintf("%dh", converted_mtbf * 24)
+	}
+	duration, err := time.ParseDuration(mtbf)
+	if err != nil {
+		return 0, err
+	}
+	one_minute, _ := time.ParseDuration("1m")
+	if duration < one_minute {
+		return 0, errors.New("smallest valid mtbf is one minute.")
+	}
+	return duration, nil
+}
+
 // RandomTimeInRange returns a random time within the range specified by startHour and endHour
-func RandomTimeInRange(startHour int, endHour int, loc *time.Location) time.Time {
-	// calculate the number of minutes in the range
-	minutesInRange := (endHour - startHour) * 60
+func RandomTimeInRange(mtbf string, startHour int, endHour int, loc *time.Location) []time.Time {
+	var times []time.Time
+	tmptimeDuration, err := ParseMtbf(mtbf)
+	if err != nil {
+		glog.Errorf("error parsing customized mtbf %s: %v", mtbf, err)
+		return []time.Time{time.Now().Add(time.Duration(24*365*10) * time.Hour)}
+	}
 
-	// calculate a random minute-offset in range [0, minutesInRange)
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	randMinuteOffset := r.Intn(minutesInRange)
-	offsetDuration := time.Duration(randMinuteOffset) * time.Minute
+	one_day, _ := time.ParseDuration("24h")
 
-	// Add the minute offset to the start of the range to get a random
-	// time within the range
-	year, month, date := time.Now().Date()
-	rangeStart := time.Date(year, month, date, startHour, 0, 0, 0, loc)
-	return rangeStart.Add(offsetDuration)
+	// If the mtbf is bigger or equal to one day we will calculate one
+	// random time in the range. If not we will calculate several random
+	// times.
+	if tmptimeDuration >= one_day {
+		// calculate the number of minutes in the range
+		minutesInRange := (endHour - startHour) * 60
+
+		// calculate a random minute-offset in range [0, minutesInRange)
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		randMinuteOffset := r.Intn(minutesInRange)
+		offsetDuration := time.Duration(randMinuteOffset) * time.Minute
+
+		// Add the minute offset to the start of the range to get a random
+		// time within the range
+		year, month, date := time.Now().Date()
+		rangeStart := time.Date(year, month, date, startHour, 0, 0, 0, loc)
+		times = append(times, rangeStart.Add(offsetDuration))
+		return times
+	} else {
+		startTime := time.Now().In(loc)
+
+		for {
+			//time range should be twice of the input mean time between failure value
+			timeDuration := tmptimeDuration * 2
+			//compute random offset time
+			mtbfEndTime := startTime.Add(timeDuration)
+			subSecond := int64(mtbfEndTime.Sub(startTime) / time.Second)
+			r := rand.New(rand.NewSource(time.Now().UnixNano()))
+			randSecondOffset := r.Int63n(subSecond)
+			randCalTime := startTime.Add(time.Duration(randSecondOffset) * time.Second)
+
+			// compute randSecondOffset between start and end hour
+			year, month, date := startTime.Date()
+			todayEndTime := time.Date(year, month, date, endHour, 0, 0, 0, loc)
+			todayStartTime := time.Date(year, month, date, startHour, 0, 0, 0, loc)
+			if startTime.Before(todayStartTime) { // now is earlier then start hour, only for test pass, normal process won't run into this condition
+				return []time.Time{todayStartTime}
+			}
+			if randCalTime.Before(todayEndTime) { // time offset before today's endHour
+				glog.V(1).Infof("RandomTimeInRange calculate time %s", randCalTime)
+				times = append(times, randCalTime)
+				// Move start time up to the calculated random time
+				startTime = randCalTime
+			} else {
+				return times
+			}
+		}
+	}
 }

--- a/internal/pkg/calendar/calendar.go
+++ b/internal/pkg/calendar/calendar.go
@@ -80,41 +80,98 @@ func ParseMtbf(mtbf string) (time.Duration, error) {
 	return duration, nil
 }
 
-// RandomTimeInRange returns a random time within the range specified by startHour and endHour
+// RandomOffsetTime returns a random time offset from the given start time within the given time window
+func RandomOffsetTime(r *rand.Rand, startTime time.Time, timeWindow time.Duration) time.Time {
+	// Convert the time window into seconds and get a random number of seconds within that window
+	subSecond := int64(timeWindow / time.Second)
+	randSecondOffset := r.Int63n(subSecond)
+	// Add the random time offset to the start time before returning it to the caller
+	randCalTime := startTime.Add(time.Duration(randSecondOffset) * time.Second)
+	return randCalTime
+}
+
+// RandomTimeInRange returns a slice of random times within the range specified by startHour and endHour
 func RandomTimeInRange(mtbf string, startHour int, endHour int, loc *time.Location) []time.Time {
 	var times []time.Time
+
+	// Parse the mtbf (mean time between failure) and convert it into a time
+	// duration that should be twice the length of the mtbf. It is an average
+	// after all.
 	tmptimeDuration, err := ParseMtbf(mtbf)
 	if err != nil {
 		glog.Errorf("error parsing customized mtbf %s: %v", mtbf, err)
 		return []time.Time{time.Now().Add(time.Duration(24*365*10) * time.Hour)}
 	}
+	timeDuration := tmptimeDuration * 2
 
+	// Initialize (seed) a random number generator and deduce the current start
+	// time of schedule creation for future reference.
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	startTime := time.Now().In(loc)
 
-	for {
-		//time range should be twice of the input mean time between failure value
-		timeDuration := tmptimeDuration * 2
-		//compute random offset time
-		mtbfEndTime := startTime.Add(timeDuration)
-		subSecond := int64(mtbfEndTime.Sub(startTime) / time.Second)
-		r := rand.New(rand.NewSource(time.Now().UnixNano()))
-		randSecondOffset := r.Int63n(subSecond)
-		randCalTime := startTime.Add(time.Duration(randSecondOffset) * time.Second)
+	// Deduce the time window of operation.
+	year, month, date := startTime.Date()
+	todayStartTime := time.Date(year, month, date, startHour, 0, 0, 0, loc)
+	todayEndTime := time.Date(year, month, date, endHour, 0, 0, 0, loc)
+	timeWindow := todayEndTime.Sub(todayStartTime)
 
-		// compute randSecondOffset between start and end hour
-		year, month, date := startTime.Date()
-		todayEndTime := time.Date(year, month, date, endHour, 0, 0, 0, loc)
-		todayStartTime := time.Date(year, month, date, startHour, 0, 0, 0, loc)
-		if startTime.Before(todayStartTime) { // now is earlier then start hour, only for test pass, normal process won't run into this condition
-			return []time.Time{todayStartTime}
-		}
-		if randCalTime.Before(todayEndTime) { // time offset before today's endHour
-			glog.V(1).Infof("RandomTimeInRange calculate time %s", randCalTime)
-			times = append(times, randCalTime)
-			// Move start time up to the calculated random time
-			startTime = randCalTime
+	// If the time duration (mbtf * 2) is bigger than the available time window
+	// the full 24 hour day is used to calculate the probability. If only using
+	// the time window it will result in incorrect probability. In this case only
+	// one time calculation is needed as the mtbf is bigger than the available
+	// time window resulting in only one occurence within the time window if
+	// probability makes it occur anyway.
+	//
+	// If the time duration is smaller than the time window it will fit at least
+	// one but most probably many times within it. For that reason  the
+	// occurances are calculated in a tiny different fashion, making sure they
+	// each and everyone will fit within the time window.
+	//
+	// Since both cases need at least one run this is exactly what the above
+	// loop is doing.
+	for again := true; again; {
+		// Is the time window bigger than the time duration? If so this loop
+		// will run again and again.
+		timeWindowBiggerThanTimeDuration := timeWindow > timeDuration
+		again = timeWindowBiggerThanTimeDuration
+		if timeWindowBiggerThanTimeDuration {
+			// It is indeed bigger, so a random offset is calculated and added
+			// to the start time of the schedule creation.
+			mtbfEndTime := startTime.Add(timeDuration)
+			randCalTime := RandomOffsetTime(r, startTime, mtbfEndTime.Sub(startTime))
+			// Check if the new calculated time is within the time window. It must
+			// be before the end of day and ...
+			if randCalTime.Before(todayEndTime) {
+				// ... after the start of day.
+				if startTime.After(todayStartTime) {
+					// Yes it is! Add it to the calculated slice of times.
+					times = append(times, randCalTime)
+				}
+				// If is was or was not, either way move start time up to the
+				// calculated random time for the next calculation.
+				startTime = randCalTime
+			} else {
+				// The latest calculated time is after the end of day, so no
+				// need to calculate more times.
+				again = false
+			}
 		} else {
-			return times
+			// The time window was not bigger, so only calculate one time as
+			// described above. First take a time definition of one day and divide it
+			// by time duration. The will produce the probability that the failure
+			// need to occur today. Next get a random number in between 0 and 1 that
+			// will be used to see if the failure will occur this time or not. If it
+			// is bigger than the probability it does. Does it this time?
+			one_day, _ := time.ParseDuration("24h")
+			if (float64(one_day) / float64(timeDuration)) > r.Float64() {
+				// Yes, it does. So allow it to happen by getting a random time
+				// anywhere within the time window offset by the start of today
+				// and add it to the calculated slice of times.
+				randCalTime := RandomOffsetTime(r, todayStartTime, timeWindow)
+				times = append(times, randCalTime)
+			}
 		}
 	}
+	// Return the slice with all calculated times.
+	return times
 }

--- a/internal/pkg/calendar/calendar_test.go
+++ b/internal/pkg/calendar/calendar_test.go
@@ -20,4 +20,24 @@ func TestIsWeekDay(t *testing.T) {
 	assert.False(t, isWeekday(monday.Add(time.Hour*24*6)))
 }
 
+func TestShouldParseMtbf(t *testing.T) {
+	duration, _ := ParseMtbf("2d")
+	assert.Equal(t, time.Hour*24*2, duration)
+
+	duration, _ = ParseMtbf("2h")
+	assert.Equal(t, time.Hour*2, duration)
+
+	duration, _ = ParseMtbf("2m")
+	assert.Equal(t, time.Minute*2, duration)
+
+	// Special case where we don't have a time unit and we assume days
+	duration, _ = ParseMtbf("2")
+	assert.Equal(t, duration, time.Hour*24*2)
+}
+
+func TestParseMtbfShouldNotAllowDurationLessThanAMinute(t *testing.T) {
+	_, err := ParseMtbf("30s")
+	assert.NotNil(t, err)
+}
+
 // FIXME:  add more tests

--- a/internal/pkg/chaos/chaosmock.go
+++ b/internal/pkg/chaos/chaosmock.go
@@ -73,7 +73,7 @@ func (vm *VictimMock) IsWhitelisted() bool {
 }
 
 func NewVictimMock() *VictimMock {
-	v := victims.New(KIND, NAME, NAMESPACE, IDENTIFIER, 1)
+	v := victims.New(KIND, NAME, NAMESPACE, IDENTIFIER, "1h")
 	return &VictimMock{
 		VictimBase: *v,
 	}

--- a/internal/pkg/kubemonkey/kubemonkey.go
+++ b/internal/pkg/kubemonkey/kubemonkey.go
@@ -44,10 +44,6 @@ func Run() error {
 	}
 
 	for {
-		// Calculate duration to sleep before next run
-		sleepDuration := durationToNextRun(config.RunHour(), config.Timezone())
-		time.Sleep(sleepDuration)
-
 		schedule, err := schedule.New()
 		if err != nil {
 			glog.Fatal(err.Error())
@@ -58,6 +54,10 @@ func Run() error {
 		}
 		fmt.Println(schedule)
 		ScheduleTerminations(schedule.Entries(), notificationsClient)
+
+		// Calculate duration to sleep before next run
+		sleepDuration := durationToNextRun(config.RunHour(), config.Timezone())
+		time.Sleep(sleepDuration)
 	}
 }
 

--- a/internal/pkg/schedule/schedule_test.go
+++ b/internal/pkg/schedule/schedule_test.go
@@ -87,16 +87,16 @@ func TestStringWithEntries(t *testing.T) {
 
 func TestCalculateKillTimeRandom(t *testing.T) {
 	config.SetDefaults()
-	killtime := CalculateKillTime()
+	killtimes := CalculateKillTimes("1h")
 
 	scheduledTime := func() (success bool) {
-		if killtime.Hour() >= config.StartHour() && killtime.Hour() <= config.EndHour() {
+		if killtimes[0].Hour() >= config.StartHour() && killtimes[0].Hour() <= config.EndHour() {
 			success = true
 		}
 		return
 	}
 
-	assert.Equal(t, killtime.Location(), config.Timezone())
+	assert.Equal(t, killtimes[0].Location(), config.Timezone())
 	assert.Condition(t, scheduledTime)
 
 }
@@ -105,10 +105,10 @@ func TestCalculateKillTimeNow(t *testing.T) {
 	config.SetDefaults()
 	viper.SetDefault(param.DebugEnabled, true)
 	viper.SetDefault(param.DebugScheduleImmediateKill, true)
-	killtime := CalculateKillTime()
+	killtimes := CalculateKillTimes("1h")
 
-	assert.Equal(t, killtime.Location(), config.Timezone())
-	assert.WithinDuration(t, killtime, time.Now(), time.Second*time.Duration(60))
+	assert.Equal(t, killtimes[0].Location(), config.Timezone())
+	assert.WithinDuration(t, killtimes[0], time.Now(), time.Second*time.Duration(60))
 	config.SetDefaults()
 }
 

--- a/internal/pkg/schedule/schedule_test.go
+++ b/internal/pkg/schedule/schedule_test.go
@@ -111,16 +111,3 @@ func TestCalculateKillTimeNow(t *testing.T) {
 	assert.WithinDuration(t, killtimes[0], time.Now(), time.Second*time.Duration(60))
 	config.SetDefaults()
 }
-
-func TestShouldScheduleChaosNow(t *testing.T) {
-	config.SetDefaults()
-	viper.SetDefault(param.DebugEnabled, true)
-	viper.SetDefault(param.DebugForceShouldKill, true)
-	assert.True(t, ShouldScheduleChaos(100000000000))
-	config.SetDefaults()
-}
-
-func TestShouldScheduleChaosMtbf(t *testing.T) {
-	assert.False(t, ShouldScheduleChaos(100000000000))
-	assert.True(t, ShouldScheduleChaos(1))
-}

--- a/internal/pkg/victims/factory/daemonsets/daemonsets.go
+++ b/internal/pkg/victims/factory/daemonsets/daemonsets.go
@@ -2,8 +2,8 @@ package daemonsets
 
 import (
 	"fmt"
-	"strconv"
 
+	"kube-monkey/internal/pkg/calendar"
 	"kube-monkey/internal/pkg/config"
 	"kube-monkey/internal/pkg/victims"
 
@@ -44,20 +44,16 @@ func identifier(kubekind *appsv1.DaemonSet) (string, error) {
 
 // Read the mean-time-between-failures value defined by the DaemonSet
 // in the label defined by config.MtbfLabelKey
-func meanTimeBetweenFailures(kubekind *appsv1.DaemonSet) (int, error) {
+func meanTimeBetweenFailures(kubekind *appsv1.DaemonSet) (string, error) {
 	mtbf, ok := kubekind.Labels[config.MtbfLabelKey]
 	if !ok {
-		return -1, fmt.Errorf("%T %s does not have %s label", kubekind, kubekind.Name, config.MtbfLabelKey)
+		return "", fmt.Errorf("%T %s does not have %s label", kubekind, kubekind.Name, config.MtbfLabelKey)
 	}
 
-	mtbfInt, err := strconv.Atoi(mtbf)
+	_, err := calendar.ParseMtbf(mtbf)
 	if err != nil {
-		return -1, err
+		return "", fmt.Errorf("error parsing mtbf %s: %v", mtbf, err)
 	}
 
-	if !(mtbfInt > 0) {
-		return -1, fmt.Errorf("Invalid value for label %s: %d", config.MtbfLabelKey, mtbfInt)
-	}
-
-	return mtbfInt, nil
+	return mtbf, nil
 }

--- a/internal/pkg/victims/factory/daemonsets/daemonsets_test.go
+++ b/internal/pkg/victims/factory/daemonsets/daemonsets_test.go
@@ -33,7 +33,7 @@ func TestNew(t *testing.T) {
 		NAME,
 		map[string]string{
 			config.IdentLabelKey: IDENTIFIER,
-			config.MtbfLabelKey:  "1",
+			config.MtbfLabelKey:  "1h",
 		},
 	)
 	ds, err := New(&v1ds)
@@ -43,14 +43,14 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, NAME, ds.Name())
 	assert.Equal(t, NAMESPACE, ds.Namespace())
 	assert.Equal(t, IDENTIFIER, ds.Identifier())
-	assert.Equal(t, 1, ds.Mtbf())
+	assert.Equal(t, "1h", ds.Mtbf())
 }
 
 func TestInvalidIdentifier(t *testing.T) {
 	v1ds := newDaemonSet(
 		NAME,
 		map[string]string{
-			config.MtbfLabelKey: "1",
+			config.MtbfLabelKey: "1h",
 		},
 	)
 	_, err := New(&v1ds)
@@ -78,16 +78,5 @@ func TestInvalidMtbf(t *testing.T) {
 	)
 	_, err = New(&v1ds)
 
-	assert.Errorf(t, err, "Expected an error if "+config.MtbfLabelKey+" label can't be converted a Int type")
-
-	v1ds = newDaemonSet(
-		NAME,
-		map[string]string{
-			config.IdentLabelKey: IDENTIFIER,
-			config.MtbfLabelKey:  "0",
-		},
-	)
-	_, err = New(&v1ds)
-
-	assert.Errorf(t, err, "Expected an error if "+config.MtbfLabelKey+" label is lower than 1")
+	assert.Errorf(t, err, "Expected an error if "+config.MtbfLabelKey+" label can't be converted a time.Duration type")
 }

--- a/internal/pkg/victims/factory/daemonsets/eligible_daemonsets_test.go
+++ b/internal/pkg/victims/factory/daemonsets/eligible_daemonsets_test.go
@@ -15,7 +15,7 @@ func TestEligibleDaemonSets(t *testing.T) {
 		NAME,
 		map[string]string{
 			"kube-monkey/identifier": "1",
-			"kube-monkey/mtbf":       "1",
+			"kube-monkey/mtbf":       "1h",
 		},
 	)
 
@@ -30,7 +30,7 @@ func TestIsEnrolled(t *testing.T) {
 		NAME,
 		map[string]string{
 			config.IdentLabelKey:   "1",
-			config.MtbfLabelKey:    "1",
+			config.MtbfLabelKey:    "1h",
 			config.EnabledLabelKey: config.EnabledLabelValue,
 		},
 	)
@@ -49,7 +49,7 @@ func TestIsNotEnrolled(t *testing.T) {
 		NAME,
 		map[string]string{
 			config.IdentLabelKey:   "1",
-			config.MtbfLabelKey:    "1",
+			config.MtbfLabelKey:    "1h",
 			config.EnabledLabelKey: "x",
 		},
 	)
@@ -66,7 +66,7 @@ func TestIsNotEnrolled(t *testing.T) {
 func TestKillType(t *testing.T) {
 
 	ident := "1"
-	mtbf := "1"
+	mtbf := "1h"
 	killMode := "kill-mode"
 
 	v1ds := newDaemonSet(
@@ -104,7 +104,7 @@ func TestKillType(t *testing.T) {
 func TestKillValue(t *testing.T) {
 
 	ident := "1"
-	mtbf := "1"
+	mtbf := "1h"
 	killValue := "0"
 
 	v1ds := newDaemonSet(

--- a/internal/pkg/victims/factory/deployments/deployments.go
+++ b/internal/pkg/victims/factory/deployments/deployments.go
@@ -2,8 +2,8 @@ package deployments
 
 import (
 	"fmt"
-	"strconv"
 
+	"kube-monkey/internal/pkg/calendar"
 	"kube-monkey/internal/pkg/config"
 	"kube-monkey/internal/pkg/victims"
 
@@ -44,20 +44,16 @@ func identifier(kubekind *appsv1.Deployment) (string, error) {
 
 // Read the mean-time-between-failures value defined by the Deployment
 // in the label defined by config.MtbfLabelKey
-func meanTimeBetweenFailures(kubekind *appsv1.Deployment) (int, error) {
+func meanTimeBetweenFailures(kubekind *appsv1.Deployment) (string, error) {
 	mtbf, ok := kubekind.Labels[config.MtbfLabelKey]
 	if !ok {
-		return -1, fmt.Errorf("%T %s does not have %s label", kubekind, kubekind.Name, config.MtbfLabelKey)
+		return "", fmt.Errorf("%T %s does not have %s label", kubekind, kubekind.Name, config.MtbfLabelKey)
 	}
 
-	mtbfInt, err := strconv.Atoi(mtbf)
+	_, err := calendar.ParseMtbf(mtbf)
 	if err != nil {
-		return -1, err
+		return "", fmt.Errorf("error parsing mtbf %s: %v", mtbf, err)
 	}
 
-	if !(mtbfInt > 0) {
-		return -1, fmt.Errorf("Invalid value for label %s: %d", config.MtbfLabelKey, mtbfInt)
-	}
-
-	return mtbfInt, nil
+	return mtbf, nil
 }

--- a/internal/pkg/victims/factory/deployments/deployments_test.go
+++ b/internal/pkg/victims/factory/deployments/deployments_test.go
@@ -33,7 +33,7 @@ func TestNew(t *testing.T) {
 		NAME,
 		map[string]string{
 			config.IdentLabelKey: IDENTIFIER,
-			config.MtbfLabelKey:  "1",
+			config.MtbfLabelKey:  "1h",
 		},
 	)
 	depl, err := New(&v1depl)
@@ -43,14 +43,14 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, NAME, depl.Name())
 	assert.Equal(t, NAMESPACE, depl.Namespace())
 	assert.Equal(t, IDENTIFIER, depl.Identifier())
-	assert.Equal(t, 1, depl.Mtbf())
+	assert.Equal(t, "1h", depl.Mtbf())
 }
 
 func TestInvalidIdentifier(t *testing.T) {
 	v1depl := newDeployment(
 		NAME,
 		map[string]string{
-			config.MtbfLabelKey: "1",
+			config.MtbfLabelKey: "1h",
 		},
 	)
 	_, err := New(&v1depl)
@@ -78,16 +78,5 @@ func TestInvalidMtbf(t *testing.T) {
 	)
 	_, err = New(&v1depl)
 
-	assert.Errorf(t, err, "Expected an error if "+config.MtbfLabelKey+" label can't be converted a Int type")
-
-	v1depl = newDeployment(
-		NAME,
-		map[string]string{
-			config.IdentLabelKey: IDENTIFIER,
-			config.MtbfLabelKey:  "0",
-		},
-	)
-	_, err = New(&v1depl)
-
-	assert.Errorf(t, err, "Expected an error if "+config.MtbfLabelKey+" label is lower than 1")
+	assert.Errorf(t, err, "Expected an error if "+config.MtbfLabelKey+" label can't be converted a time.Duration type")
 }

--- a/internal/pkg/victims/factory/deployments/eligible_deployments_test.go
+++ b/internal/pkg/victims/factory/deployments/eligible_deployments_test.go
@@ -15,7 +15,7 @@ func TestEligibleDeployments(t *testing.T) {
 		NAME,
 		map[string]string{
 			"kube-monkey/identifier": "1",
-			"kube-monkey/mtbf":       "1",
+			"kube-monkey/mtbf":       "1h",
 		},
 	)
 
@@ -30,7 +30,7 @@ func TestIsEnrolled(t *testing.T) {
 		NAME,
 		map[string]string{
 			config.IdentLabelKey:   "1",
-			config.MtbfLabelKey:    "1",
+			config.MtbfLabelKey:    "1h",
 			config.EnabledLabelKey: config.EnabledLabelValue,
 		},
 	)
@@ -49,7 +49,7 @@ func TestIsNotEnrolled(t *testing.T) {
 		NAME,
 		map[string]string{
 			config.IdentLabelKey:   "1",
-			config.MtbfLabelKey:    "1",
+			config.MtbfLabelKey:    "1h",
 			config.EnabledLabelKey: "x",
 		},
 	)
@@ -66,7 +66,7 @@ func TestIsNotEnrolled(t *testing.T) {
 func TestKillType(t *testing.T) {
 
 	ident := "1"
-	mtbf := "1"
+	mtbf := "1h"
 	killMode := "kill-mode"
 
 	v1depl := newDeployment(
@@ -104,7 +104,7 @@ func TestKillType(t *testing.T) {
 func TestKillValue(t *testing.T) {
 
 	ident := "1"
-	mtbf := "1"
+	mtbf := "1h"
 	killValue := "0"
 
 	v1depl := newDeployment(

--- a/internal/pkg/victims/factory/statefulsets/eligible_statefulsets_test.go
+++ b/internal/pkg/victims/factory/statefulsets/eligible_statefulsets_test.go
@@ -15,7 +15,7 @@ func TestEligibleStatefulSets(t *testing.T) {
 		NAME,
 		map[string]string{
 			"kube-monkey/identifier": "1",
-			"kube-monkey/mtbf":       "1",
+			"kube-monkey/mtbf":       "1h",
 		},
 	)
 
@@ -30,7 +30,7 @@ func TestIsEnrolled(t *testing.T) {
 		NAME,
 		map[string]string{
 			config.IdentLabelKey:   "1",
-			config.MtbfLabelKey:    "1",
+			config.MtbfLabelKey:    "1h",
 			config.EnabledLabelKey: config.EnabledLabelValue,
 		},
 	)
@@ -49,7 +49,7 @@ func TestIsNotEnrolled(t *testing.T) {
 		NAME,
 		map[string]string{
 			config.IdentLabelKey:   "1",
-			config.MtbfLabelKey:    "1",
+			config.MtbfLabelKey:    "1h",
 			config.EnabledLabelKey: "x",
 		},
 	)
@@ -66,7 +66,7 @@ func TestIsNotEnrolled(t *testing.T) {
 func TestKillType(t *testing.T) {
 
 	ident := "1"
-	mtbf := "1"
+	mtbf := "1h"
 	killMode := "kill-mode"
 
 	v1stfs := newStatefulSet(
@@ -104,7 +104,7 @@ func TestKillType(t *testing.T) {
 func TestKillValue(t *testing.T) {
 
 	ident := "1"
-	mtbf := "1"
+	mtbf := "1h"
 	killValue := "0"
 
 	v1stfs := newStatefulSet(

--- a/internal/pkg/victims/factory/statefulsets/statefulset_test.go
+++ b/internal/pkg/victims/factory/statefulsets/statefulset_test.go
@@ -33,7 +33,7 @@ func TestNew(t *testing.T) {
 		NAME,
 		map[string]string{
 			config.IdentLabelKey: IDENTIFIER,
-			config.MtbfLabelKey:  "1",
+			config.MtbfLabelKey:  "1h",
 		},
 	)
 	stfs, err := New(&v1stfs)
@@ -43,14 +43,14 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, NAME, stfs.Name())
 	assert.Equal(t, NAMESPACE, stfs.Namespace())
 	assert.Equal(t, IDENTIFIER, stfs.Identifier())
-	assert.Equal(t, 1, stfs.Mtbf())
+	assert.Equal(t, "1h", stfs.Mtbf())
 }
 
 func TestInvalidIdentifier(t *testing.T) {
 	v1stfs := newStatefulSet(
 		NAME,
 		map[string]string{
-			config.MtbfLabelKey: "1",
+			config.MtbfLabelKey: "1h",
 		},
 	)
 	_, err := New(&v1stfs)
@@ -78,16 +78,5 @@ func TestInvalidMtbf(t *testing.T) {
 	)
 	_, err = New(&v1stfs)
 
-	assert.Errorf(t, err, "Expected an error if "+config.MtbfLabelKey+" label can't be converted a Int type")
-
-	v1stfs = newStatefulSet(
-		NAME,
-		map[string]string{
-			config.IdentLabelKey: IDENTIFIER,
-			config.MtbfLabelKey:  "0",
-		},
-	)
-	_, err = New(&v1stfs)
-
-	assert.Errorf(t, err, "Expected an error if "+config.MtbfLabelKey+" label is lower than 1")
+	assert.Errorf(t, err, "Expected an error if "+config.MtbfLabelKey+" label can't be converted a time.Duration type")
 }

--- a/internal/pkg/victims/factory/statefulsets/statefulsets.go
+++ b/internal/pkg/victims/factory/statefulsets/statefulsets.go
@@ -2,8 +2,8 @@ package statefulsets
 
 import (
 	"fmt"
-	"strconv"
 
+	"kube-monkey/internal/pkg/calendar"
 	"kube-monkey/internal/pkg/config"
 	"kube-monkey/internal/pkg/victims"
 
@@ -44,20 +44,16 @@ func identifier(kubekind *corev1.StatefulSet) (string, error) {
 
 // Read the mean-time-between-failures value defined by the StatefulSet
 // in the label defined by config.MtbfLabelKey
-func meanTimeBetweenFailures(kubekind *corev1.StatefulSet) (int, error) {
+func meanTimeBetweenFailures(kubekind *corev1.StatefulSet) (string, error) {
 	mtbf, ok := kubekind.Labels[config.MtbfLabelKey]
 	if !ok {
-		return -1, fmt.Errorf("%T %s does not have %s label", kubekind, kubekind.Name, config.MtbfLabelKey)
+		return "", fmt.Errorf("%T %s does not have %s label", kubekind, kubekind.Name, config.MtbfLabelKey)
 	}
 
-	mtbfInt, err := strconv.Atoi(mtbf)
+	_, err := calendar.ParseMtbf(mtbf)
 	if err != nil {
-		return -1, err
+		return "", fmt.Errorf("error parsing mtbf %s: %v", mtbf, err)
 	}
 
-	if !(mtbfInt > 0) {
-		return -1, fmt.Errorf("Invalid value for label %s: %d", config.MtbfLabelKey, mtbfInt)
-	}
-
-	return mtbfInt, nil
+	return mtbf, nil
 }

--- a/internal/pkg/victims/victims.go
+++ b/internal/pkg/victims/victims.go
@@ -33,7 +33,7 @@ type VictimBaseTemplate interface {
 	Name() string
 	Namespace() string
 	Identifier() string
-	Mtbf() int
+	Mtbf() string
 
 	VictimAPICalls
 }
@@ -67,12 +67,12 @@ type VictimBase struct {
 	name       string
 	namespace  string
 	identifier string
-	mtbf       int
+	mtbf       string
 
 	VictimBaseTemplate
 }
 
-func New(kind, name, namespace, identifier string, mtbf int) *VictimBase {
+func New(kind, name, namespace, identifier string, mtbf string) *VictimBase {
 	return &VictimBase{kind: kind, name: name, namespace: namespace, identifier: identifier, mtbf: mtbf}
 }
 
@@ -92,7 +92,7 @@ func (v *VictimBase) Identifier() string {
 	return v.identifier
 }
 
-func (v *VictimBase) Mtbf() int {
+func (v *VictimBase) Mtbf() string {
 	return v.mtbf
 }
 

--- a/internal/pkg/victims/victims_test.go
+++ b/internal/pkg/victims/victims_test.go
@@ -59,7 +59,7 @@ func generateNRunningPods(namePrefix string, n int) []runtime.Object {
 }
 
 func newVictimBase() *VictimBase {
-	return New(KIND, NAME, NAMESPACE, IDENTIFIER, 1)
+	return New(KIND, NAME, NAMESPACE, IDENTIFIER, "1h")
 }
 
 func getPodList(client kube.Interface) *corev1.PodList {
@@ -75,7 +75,7 @@ func TestVictimBaseTemplateGetters(t *testing.T) {
 	assert.Equal(t, "name", v.Name())
 	assert.Equal(t, NAMESPACE, v.Namespace())
 	assert.Equal(t, IDENTIFIER, v.Identifier())
-	assert.Equal(t, 1, v.Mtbf())
+	assert.Equal(t, "1h", v.Mtbf())
 }
 
 func TestRunningPods(t *testing.T) {
@@ -304,7 +304,7 @@ func TestIsBlacklisted(t *testing.T) {
 	b := v.IsBlacklisted()
 	assert.False(t, b, "%s namespace should not be blacklisted", NAMESPACE)
 
-	v = New("Pod", "name", metav1.NamespaceSystem, IDENTIFIER, 1)
+	v = New("Pod", "name", metav1.NamespaceSystem, IDENTIFIER, "1h")
 	b = v.IsBlacklisted()
 	assert.True(t, b, "%s namespace should be blacklisted", metav1.NamespaceSystem)
 


### PR DESCRIPTION
This PR changes the definition of "kube-monkey/mtbf".

Alike https://github.com/misgod-yy in https://github.com/asobti/kube-monkey/pull/168 we needed a more fine grained control for the mean time between failure. A couple of years ago a coworker of mine took the misgod-yy patches and updated a now very old version of your software, fixed the problems with that code and we have been using this happily ever since for several years now.

The downside of this approach was that we were still using this very old version of the software and recently decided that's not okay anymore. Hence I ported our patches to the newest version of your code and improved it a tiny bit. Please bare with me, this is the first Golang programming I did.

Please review my work. I think it solves all the issues you had with the more early work of https://github.com/misgod-yy. It for instance sticks to minutes, hours and days, it removed the weird naming and last but not least is no breaking change as one can specify days as a simply integer (old style) and as an integer with an additional d-unit (new-style).

 I hope you like it.